### PR TITLE
Bring sandbox platform cluster virtual machines under terraform control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**/.terraform
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 Terraform IaC
 
 ## Terraform state
-Terraform is configured to store is state in a GCS bucket. The state file is
+Terraform is configured to store its state in a GCS bucket. The state file is
 located at gs://terraform-support-<project>/state/default.tfstate.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # terraform-support
 Terraform IaC
+
+## Terraform state
+Terraform is configured to store is state in a GCS bucket. The state file is
+located at gs://terraform-support-<project>/state/default.tfstate.
+

--- a/import_existing_resources.sh
+++ b/import_existing_resources.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Imports existing infrastructure into the terraform state.
+
+PROJECT=${1:? Please provide a project name}
+
+# A bash associative array. Pretend you didn't see this.
+declare -A resource_id_templates=(
+	["google_compute_address"]="projects/{{project}}/regions/{{region}}/addresses/{{name}}"
+	["google_compute_disk"]="projects/{{project}}/zones/{{zone}}/disks/{{name}}"
+	["google_compute_instance"]="projects/{{project}}/zones/{{zone}}/instances/{{name}}"
+)
+
+pushd $PROJECT
+
+terraform plan -out plan.tfplan > /dev/null
+
+# base64 encode each change, in case there are newlines in the data.
+for change in $(terraform show -json plan.tfplan | jq -r '.resource_changes[] | @base64'); do
+  c=$(echo $change | base64 --decode)
+  address=$(echo $c| jq -r '.address')
+  name=$(echo $c| jq -r '.change.after.name')
+  region=$(echo $c| jq -r '.change.after.region')
+  resource_type=$(echo $c| jq -r '.type')
+  zone=$(echo $c| jq -r '.change.after.zone')
+
+  template=${resource_id_templates[$resource_type]}
+
+  resource_id=$(
+	echo $template | \
+	sed -e "s/{{project}}/${PROJECT}/" \
+	    -e "s/{{region}}/${region}/" \
+		-e "s/{{name}}/${name}/" \
+		-e "s/{{zone}}/${zone}/"
+  )
+
+  # Import the resource if it doesn't exist in the current state. The following
+  # command will exit with a status of 0 if the resource is in the current
+  # state.
+  terraform state show "${address}" &> /dev/null
+  if [[ $? -ne 0 ]]; then
+    terraform import "${address}" "${resource_id}"
+  fi
+done
+
+rm plan.tfplan
+
+popd

--- a/import_existing_resources.sh
+++ b/import_existing_resources.sh
@@ -6,9 +6,9 @@ PROJECT=${1:? Please provide a project name}
 
 # A bash associative array. Pretend you didn't see this.
 declare -A resource_id_templates=(
-	["google_compute_address"]="projects/{{project}}/regions/{{region}}/addresses/{{name}}"
-	["google_compute_disk"]="projects/{{project}}/zones/{{zone}}/disks/{{name}}"
-	["google_compute_instance"]="projects/{{project}}/zones/{{zone}}/instances/{{name}}"
+  ["google_compute_address"]="projects/{{project}}/regions/{{region}}/addresses/{{name}}"
+  ["google_compute_disk"]="projects/{{project}}/zones/{{zone}}/disks/{{name}}"
+  ["google_compute_instance"]="projects/{{project}}/zones/{{zone}}/instances/{{name}}"
 )
 
 pushd $PROJECT
@@ -27,11 +27,11 @@ for change in $(terraform show -json plan.tfplan | jq -r '.resource_changes[] | 
   template=${resource_id_templates[$resource_type]}
 
   resource_id=$(
-	echo $template | \
-	sed -e "s/{{project}}/${PROJECT}/" \
-	    -e "s/{{region}}/${region}/" \
-		-e "s/{{name}}/${name}/" \
-		-e "s/{{zone}}/${zone}/"
+    echo $template | \
+    sed -e "s/{{project}}/${PROJECT}/" \
+        -e "s/{{region}}/${region}/" \
+        -e "s/{{name}}/${name}/" \
+        -e "s/{{zone}}/${zone}/"
   )
 
   # Import the resource if it doesn't exist in the current state. The following

--- a/import_existing_resources.sh
+++ b/import_existing_resources.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 #
 # Imports existing infrastructure into the terraform state.
+#
+# Terraform will refuse to manage infrastructure that already exists for which it does
+# not have state on. Each existing resource you want terraform to manage must be
+# "imported" into terraform's state. This is a convenience script to automate
+# bulk import of existing infrastruture. Once all infrastructure is under
+# terraform control, this script will no longer be useful. The process looks
+# something like:
+#
+# * Write terraform configs for existing infrastructure.
+# * Run this script to import these resource into terraform's state.
+# * Run `terraform apply` to apply any changes.
 
 PROJECT=${1:? Please provide a project name}
 

--- a/mlab-sandbox/.terraform.lock.hcl
+++ b/mlab-sandbox/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.45.0"
+  constraints = "4.45.0"
+  hashes = [
+    "h1:mO+VA/Mf/X3RbgNXfcslci/DT/yo2EK0E8lG0qAoBMo=",
+    "zh:1646acf259d81d72bec2f5f6b0fe942f96195bbd52bf9efcc7f2c444533dce33",
+    "zh:452d09ce51ae0c8f57cb5831807441e089cd41585b1a0635154d5f4d4912e372",
+    "zh:46c884f7d404f228f1d923dfcdb28d62a091d8b9ce07f54779bceebc57e53f93",
+    "zh:4eb3ad3640ae00d5f85f56fdfcf6784342f73bebda4c952ce7f2bbdf79734662",
+    "zh:5365a761631b0cecb38517c75e00dabef1a3cd148f59a198a81c121b62ef54ea",
+    "zh:68b95bf9e54ff4d244ae6599b08abec18e07613b3eb36a3f1c0305e06ffb8972",
+    "zh:75b4bb2282a31a0549725b04d0f445649eb2cb36d2e424a487bf7df022bcbb26",
+    "zh:9644e91492faa0386f81fe1bdcd18fe00b3800908b4c5fb20cec9f198e4069b5",
+    "zh:b214b119657bdc09943e95c0b66f069de1bcf333660856d51dcb95a1263ad9d4",
+    "zh:c28b4abdd43cc63ff0e0a4c9ea9e5826d91662006d1d131bad53964aff855edf",
+    "zh:da9379d0645e015c7bb5a5fccd4a1388b3a840d48450a99e3f8fe18efdd90aa4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/mlab-sandbox/main.tf
+++ b/mlab-sandbox/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  backend "gcs" {
+    bucket = "terraform-support-mlab-sandbox"
+    prefix = "state"
+  }
+}
+
+provider "google" {
+  project = "mlab-sandbox"
+  region  = "us-central1"
+  zone    = "us-central1-c"
+}
+
+module "platform-cluster" {
+  project = "mlab-sandbox"
+  source  = "./platform-cluster"
+}

--- a/mlab-sandbox/platform-cluster/mlab1-chs0t-mlab-sandbox-measurement-lab-org.tf
+++ b/mlab-sandbox/platform-cluster/mlab1-chs0t-mlab-sandbox-measurement-lab-org.tf
@@ -1,0 +1,45 @@
+resource "google_compute_instance" "mlab1_chs0t_mlab_sandbox_measurement_lab_org" {
+  boot_disk {
+    source = google_compute_disk.mlab1_chs0t_mlab_sandbox_measurement_lab_org.id
+  }
+
+  hostname     = "mlab1-chs0t.mlab-sandbox.measurement-lab.org"
+  machine_type = var.machine_type
+  name         = "mlab1-chs0t-mlab-sandbox-measurement-lab-org"
+
+  network_interface {
+    access_config {
+      nat_ip = google_compute_address.mlab1_chs0t_mlab_sandbox_measurement_lab_org.address
+    }
+    ipv6_access_config {
+      network_tier = "PREMIUM"
+    }
+    network    = var.network
+    stack_type = var.stack_type
+    subnetwork = var.subnetwork
+  }
+
+  project = var.project
+
+  service_account {
+    scopes = var.vm_scopes
+  }
+
+  tags = var.tags
+  zone = "us-east1-c"
+}
+
+resource "google_compute_address" "mlab1_chs0t_mlab_sandbox_measurement_lab_org" {
+  address_type = "EXTERNAL"
+  name         = "mlab1-chs0t-mlab-sandbox-measurement-lab-org"
+  project      = var.project
+  region       = "us-east1"
+}
+
+resource "google_compute_disk" "mlab1_chs0t_mlab_sandbox_measurement_lab_org" {
+  image = var.disk_image
+  name  = "mlab1-chs0t-mlab-sandbox-measurement-lab-org"
+  size  = var.disk_size_gb
+  type  = "pd-ssd"
+  zone  = "us-east1-c"
+}

--- a/mlab-sandbox/platform-cluster/mlab1-lax0t-mlab-sandbox-measurement-lab-org.tf
+++ b/mlab-sandbox/platform-cluster/mlab1-lax0t-mlab-sandbox-measurement-lab-org.tf
@@ -1,0 +1,45 @@
+resource "google_compute_instance" "mlab1_lax0t_mlab_sandbox_measurement_lab_org" {
+  boot_disk {
+    source = google_compute_disk.mlab1_lax0t_mlab_sandbox_measurement_lab_org.id
+  }
+
+  hostname     = "mlab1-lax0t.mlab-sandbox.measurement-lab.org"
+  machine_type = var.machine_type
+  name         = "mlab1-lax0t-mlab-sandbox-measurement-lab-org"
+
+  network_interface {
+    access_config {
+      nat_ip = google_compute_address.mlab1_lax0t_mlab_sandbox_measurement_lab_org.address
+    }
+    ipv6_access_config {
+      network_tier = "PREMIUM"
+    }
+    network    = var.network
+    stack_type = var.stack_type
+    subnetwork = var.subnetwork
+  }
+
+  project = var.project
+
+  service_account {
+    scopes = var.vm_scopes
+  }
+
+  tags = var.tags
+  zone = "us-west2-c"
+}
+
+resource "google_compute_address" "mlab1_lax0t_mlab_sandbox_measurement_lab_org" {
+  address_type = "EXTERNAL"
+  name         = "mlab1-lax0t-mlab-sandbox-measurement-lab-org"
+  project      = var.project
+  region       = "us-west2"
+}
+
+resource "google_compute_disk" "mlab1_lax0t_mlab_sandbox_measurement_lab_org" {
+  image = var.disk_image
+  name  = "mlab1-lax0t-mlab-sandbox-measurement-lab-org"
+  size  = var.disk_size_gb
+  type  = "pd-ssd"
+  zone  = "us-west2-c"
+}

--- a/mlab-sandbox/platform-cluster/mlab1-pdx0t-mlab-sandbox-measurement-lab-org.tf
+++ b/mlab-sandbox/platform-cluster/mlab1-pdx0t-mlab-sandbox-measurement-lab-org.tf
@@ -1,0 +1,45 @@
+resource "google_compute_instance" "mlab1_pdx0t_mlab_sandbox_measurement_lab_org" {
+  boot_disk {
+    source = google_compute_disk.mlab1_pdx0t_mlab_sandbox_measurement_lab_org.id
+  }
+
+  hostname     = "mlab1-pdx0t.mlab-sandbox.measurement-lab.org"
+  machine_type = var.machine_type
+  name         = "mlab1-pdx0t-mlab-sandbox-measurement-lab-org"
+
+  network_interface {
+    access_config {
+      nat_ip = google_compute_address.mlab1_pdx0t_mlab_sandbox_measurement_lab_org.address
+    }
+    ipv6_access_config {
+      network_tier = "PREMIUM"
+    }
+    network    = var.network
+    stack_type = var.stack_type
+    subnetwork = var.subnetwork
+  }
+
+  project = var.project
+
+  service_account {
+    scopes = var.vm_scopes
+  }
+
+  tags = var.tags
+  zone = "us-west1-c"
+}
+
+resource "google_compute_address" "mlab1_pdx0t_mlab_sandbox_measurement_lab_org" {
+  address_type = "EXTERNAL"
+  name         = "mlab1-pdx0t-mlab-sandbox-measurement-lab-org"
+  project      = var.project
+  region       = "us-west1"
+}
+
+resource "google_compute_disk" "mlab1_pdx0t_mlab_sandbox_measurement_lab_org" {
+  image = var.disk_image
+  name  = "mlab1-pdx0t-mlab-sandbox-measurement-lab-org"
+  size  = var.disk_size_gb
+  type  = "pd-ssd"
+  zone  = "us-west1-c"
+}

--- a/mlab-sandbox/platform-cluster/mlab2-chs0t-mlab-sandbox-measurement-lab-org.tf
+++ b/mlab-sandbox/platform-cluster/mlab2-chs0t-mlab-sandbox-measurement-lab-org.tf
@@ -1,0 +1,45 @@
+resource "google_compute_instance" "mlab2_chs0t_mlab_sandbox_measurement_lab_org" {
+  boot_disk {
+    source = google_compute_disk.mlab2_chs0t_mlab_sandbox_measurement_lab_org.id
+  }
+
+  hostname     = "mlab2-chs0t.mlab-sandbox.measurement-lab.org"
+  machine_type = var.machine_type
+  name         = "mlab2-chs0t-mlab-sandbox-measurement-lab-org"
+
+  network_interface {
+    access_config {
+      nat_ip = google_compute_address.mlab2_chs0t_mlab_sandbox_measurement_lab_org.address
+    }
+    ipv6_access_config {
+      network_tier = "PREMIUM"
+    }
+    network    = var.network
+    stack_type = var.stack_type
+    subnetwork = var.subnetwork
+  }
+
+  project = var.project
+
+  service_account {
+    scopes = var.vm_scopes
+  }
+
+  tags = var.tags
+  zone = "us-east1-c"
+}
+
+resource "google_compute_address" "mlab2_chs0t_mlab_sandbox_measurement_lab_org" {
+  address_type = "EXTERNAL"
+  name         = "mlab2-chs0t-mlab-sandbox-measurement-lab-org"
+  project      = var.project
+  region       = "us-east1"
+}
+
+resource "google_compute_disk" "mlab2_chs0t_mlab_sandbox_measurement_lab_org" {
+  image = var.disk_image
+  name  = "mlab2-chs0t-mlab-sandbox-measurement-lab-org"
+  size  = var.disk_size_gb
+  type  = var.disk_type
+  zone  = "us-east1-c"
+}

--- a/mlab-sandbox/platform-cluster/variables.tf
+++ b/mlab-sandbox/platform-cluster/variables.tf
@@ -1,0 +1,59 @@
+variable "project" {
+  default     = "mlab-sandbox"
+  description = "The GCP project to use"
+  type        = string
+}
+
+variable "machine_type" {
+  default     = "n2-highcpu-4"
+  description = "The GCE machine-type to use for VMs"
+  type        = string
+}
+
+variable "network" {
+  default     = "mlab-platform-network"
+  description = "The VPC network to use for resources"
+  type        = string
+}
+
+variable "subnetwork" {
+  default     = "kubernetes"
+  description = "The VPC subnetwork to use for resources"
+  type        = string
+}
+
+variable "stack_type" {
+  default     = "IPV4_IPV6"
+  description = "The network stack type for VMs"
+  type        = string
+}
+
+variable "vm_scopes" {
+  default     = ["cloud-platform"]
+  description = "The access scopes to use for VMs"
+  type        = list(string)
+}
+
+variable "disk_size_gb" {
+  default     = 100
+  description = "The size of the boot disk, in GB"
+  type        = number
+}
+
+variable "disk_type" {
+  default     = "pd-ssd"
+  description = "The type of persistent disk to use for the boot disk"
+  type        = string
+}
+
+variable "disk_image" {
+  default     = "mlab-platform-cluster-latest"
+  description = "The image to use to create the boot disk"
+  type        = string
+}
+
+variable "tags" {
+  default     = ["ndt-cloud"]
+  description = "The tags to add to the VM"
+  type        = list(string)
+}

--- a/mlab-sandbox/terraform.tfvars
+++ b/mlab-sandbox/terraform.tfvars
@@ -1,0 +1,5 @@
+project = {
+  default     = "mlab-sandbox"
+  description = "The GCP project where resources should be created"
+  type        = string
+}

--- a/mlab-sandbox/versions.tf
+++ b/mlab-sandbox/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "4.45.0"
+    }
+  }
+}


### PR DESCRIPTION
This is a small start to introducing Terraform to the M-Lab projects. The configs represented in this PR bring all sandbox virtual machines under terraform control, along with their boot disks and static IPv4 addresses. 

This is just a small start. The goal will be to eliminate the need for most all of the shell scripts in the [manage-cluster directory](https://github.com/m-lab/k8s-support/tree/main/manage-cluster) of the k8s-support repository. Once the platform cluster resources are fully under terraform control, we can start bringing additional GCP resources under terraform control.

Since all of our resources already exist, the shell script `import_existing_resources.sh` was added to this repo to help import existing infrastructure into terraform state. The script will need to be updated as we add additional resource types. Once all of our infrastructure is managed by terraform, the script or anything like it will no longer be necessary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/1)
<!-- Reviewable:end -->
