### PR TITLE
Modifes resource names to match staging/prod

### DIFF
--- a/mlab-sandbox/platform-cluster/instancegroups.tf
+++ b/mlab-sandbox/platform-cluster/instancegroups.tf
@@ -69,12 +69,13 @@ resource "google_compute_region_instance_group_manager" "platform_cluster_mig_ma
   for_each = var.instances.migs
 
   base_instance_name = "${each.key}-${var.project}-measurement-lab-org"
-  name               = "platform-cluster-${each.key}"
+  name               = "${each.key}-${var.project}-measurement-lab-org"
   region             = each.value["region"]
 
   update_policy {
-    minimal_action = "REFRESH"
-    type           = "PROACTIVE"
+    max_surge_fixed = length(var.instances.migs)
+    minimal_action  = "REPLACE"
+    type            = "PROACTIVE"
   }
 
   version {
@@ -97,8 +98,7 @@ resource "google_compute_region_autoscaler" "platform_cluster_mig_autoscalers" {
     max_replicas = 9
   }
 
-
-  name   = "platform-cluster-${each.key}"
+  name   = "${each.key}-${var.project}-measurement-lab-org"
   region = each.value["region"]
   target = google_compute_region_instance_group_manager.platform_cluster_mig_managers[each.key].id
 }

--- a/mlab-sandbox/platform-cluster/instances.tf
+++ b/mlab-sandbox/platform-cluster/instances.tf
@@ -138,7 +138,7 @@ resource "google_compute_instance" "platform_instances" {
 resource "google_compute_address" "platform_addresses" {
   for_each     = var.instances.vms
   address_type = "EXTERNAL"
-  name         = "platform-cluster-${each.key}"
+  name         = "${each.key}-${var.project}-measurement-lab-org"
   # This regex is ugly, but I can't find a better way to extract the region from
   # the zone.
   region = regex("^([a-z]+-[a-z0-9]+)-[a-z]$", each.value["zone"])[0]
@@ -147,7 +147,7 @@ resource "google_compute_address" "platform_addresses" {
 resource "google_compute_disk" "platform_boot_disks" {
   for_each = var.instances.vms
   image    = var.instances.attributes.disk_image
-  name     = "platform-cluster-boot-${each.key}"
+  name     = "${each.key}-${var.project}-measurement-lab-org"
   size     = var.instances.attributes.disk_size_gb
   type     = var.instances.attributes.disk_type
   zone     = each.value["zone"]
@@ -212,7 +212,7 @@ resource "google_compute_disk" "prometheus_boot_disk" {
 }
 
 resource "google_compute_disk" "prometheus_data_disk" {
-  name = "prometheus-platform-cluster-data"
+  name = "prometheus-platform-cluster-${var.prometheus_instance.zone}"
   size = var.prometheus_instance.disk_size_gb_data
   type = var.prometheus_instance.disk_type
   zone = var.prometheus_instance.zone

--- a/mlab-sandbox/platform-cluster/loadbalancers.tf
+++ b/mlab-sandbox/platform-cluster/loadbalancers.tf
@@ -5,7 +5,7 @@ resource "google_compute_address" "platform_cluster_mig_addresses" {
   for_each = var.instances.migs
 
   address_type = "EXTERNAL"
-  name         = "platform-cluster-${each.key}"
+  name         = "${each.key}-${var.project}-measurement-lab-org"
   region       = each.value["region"]
 }
 
@@ -16,7 +16,7 @@ resource "google_compute_region_health_check" "platform_cluster_mig_health_check
     port = 443
   }
 
-  name   = "platform-cluster-${each.key}"
+  name   = "${each.key}-${var.project}-measurement-lab-org"
   region = each.value["region"]
 }
 
@@ -27,7 +27,7 @@ resource "google_compute_region_backend_service" "platform_cluster_mig_backends"
     group = google_compute_region_instance_group_manager.platform_cluster_mig_managers[each.key].instance_group
   }
 
-  name                  = "platform-cluster-${each.key}"
+  name                  = "${each.key}-${var.project}-measurement-lab-org"
   health_checks         = [google_compute_region_health_check.platform_cluster_mig_health_checks[each.key].id]
   load_balancing_scheme = "EXTERNAL"
   protocol              = "UNSPECIFIED"
@@ -43,7 +43,7 @@ resource "google_compute_forwarding_rule" "platform_cluster_mig_forwarding_rules
   ip_address            = google_compute_address.platform_cluster_mig_addresses[each.key].id
   ip_protocol           = "L3_DEFAULT"
   load_balancing_scheme = "EXTERNAL"
-  name                  = "platform-cluster-${each.key}"
+  name                  = "${each.key}-${var.project}-measurement-lab-org"
   region                = each.value["region"]
 }
 


### PR DESCRIPTION
As long as the names and configuration parameters match for resources defined in our Terraform configs with those of the actual resources already in the staging and production, then those resources can be imported into the Terraform state with no modification or disruption. This commit attempts to bring the names created by Terraform into line with how resources are already named in staging and production.