### PR TITLE
Fills in variable values for mlab-staging cluster

### DIFF
--- a/mlab-sandbox/terraform.tfvars
+++ b/mlab-sandbox/terraform.tfvars
@@ -4,7 +4,7 @@ default_zone   = "us-west2-a"
 
 instances = {
   attributes = {
-    disk_image   = "platform-cluster-instance-2023-05-12t17-52-24"
+    disk_image   = "platform-cluster-instance-2023-06-02t22-30-03"
     disk_size_gb = 100
     disk_type    = "pd-ssd"
     machine_type = "n1-highcpu-4"
@@ -32,7 +32,7 @@ instances = {
 
 api_instances = {
   machine_attributes = {
-    disk_image        = "platform-cluster-api-instance-2023-05-12t17-52-24"
+    disk_image        = "platform-cluster-api-instance-2023-06-02t22-30-03"
     disk_size_gb_boot = 100
     disk_size_gb_data = 10
     # This will show up as /dev/disk/by-id/google-<name>
@@ -66,7 +66,7 @@ api_instances = {
 }
 
 prometheus_instance = {
-  disk_image        = "platform-cluster-internal-instance-2023-05-12t17-52-24"
+  disk_image        = "platform-cluster-internal-instance-2023-06-02t22-30-03"
   disk_size_gb_boot = 100
   disk_size_gb_data = 200
   disk_type         = "pd-ssd"

--- a/mlab-sandbox/terraform.tfvars
+++ b/mlab-sandbox/terraform.tfvars
@@ -95,8 +95,8 @@ networking = {
       region        = "us-west1"
     },
     "us-east1" = {
-      name          = "kubernetes"
       ip_cidr_range = "10.4.0.0/16"
+      name          = "kubernetes"
       region        = "us-east1"
     }
   }

--- a/mlab-staging/terraform.tfvars
+++ b/mlab-staging/terraform.tfvars
@@ -4,7 +4,7 @@ default_zone   = "us-central1-a"
 
 instances = {
   attributes = {
-    disk_image   = "platform-cluster-instance-2023-05-30t21-35-06"
+    disk_image   = "platform-cluster-instance-2023-06-05t17-31-28"
     disk_size_gb = 100
     disk_type    = "pd-ssd"
     machine_type = "n1-highcpu-4"
@@ -31,7 +31,7 @@ instances = {
 
 api_instances = {
   machine_attributes = {
-    disk_image        = "platform-cluster-api-instance-2023-05-30t21-35-06"
+    disk_image        = "platform-cluster-api-instance-2023-06-05t17-31-28"
     disk_size_gb_boot = 100
     disk_size_gb_data = 10
     # This will show up as /dev/disk/by-id/google-<name>
@@ -65,7 +65,7 @@ api_instances = {
 }
 
 prometheus_instance = {
-  disk_image        = "platform-cluster-internal-instance-2023-05-30t21-35-06"
+  disk_image        = "platform-cluster-internal-instance-2023-06-05t17-31-28"
   disk_size_gb_boot = 100
   disk_size_gb_data = 1500
   disk_type         = "pd-ssd"

--- a/mlab-staging/terraform.tfvars
+++ b/mlab-staging/terraform.tfvars
@@ -4,7 +4,7 @@ default_zone   = "us-central1-a"
 
 instances = {
   attributes = {
-    disk_image   = "CHANGEME"
+    disk_image   = "platform-cluster-instance-2023-05-30t21-35-06"
     disk_size_gb = 100
     disk_type    = "pd-ssd"
     machine_type = "n1-highcpu-4"
@@ -13,18 +13,31 @@ instances = {
     scopes       = ["cloud-platform"]
   },
   migs = {},
-  vms  = {}
+  vms = {
+    mlab3-iad08 = {
+      zone = "us-east4-c"
+    },
+    mlab4-iad08 = {
+      zone = "us-east4-c"
+    },
+    mlab4-lax08 = {
+      zone = "us-west2-c"
+    },
+    mlab4-oma01 = {
+      zone = "us-central1-c"
+    }
+  }
 }
 
 api_instances = {
   machine_attributes = {
-    disk_image        = "CHANGEME"
+    disk_image        = "platform-cluster-api-instance-2023-05-30t21-35-06"
     disk_size_gb_boot = 100
     disk_size_gb_data = 10
     # This will show up as /dev/disk/by-id/google-<name>
     disk_dev_name_data = "cluster-data"
     disk_type          = "pd-ssd"
-    machine_type       = "n1-standard-2"
+    machine_type       = "n1-standard-4"
     tags               = ["platform-cluster"]
     region             = "us-central1"
     scopes             = ["cloud-platform"]
@@ -35,11 +48,24 @@ api_instances = {
     service_cidr           = "172.25.0.0/16"
     epoxy_extension_server = "epoxy-extension-server.mlab-staging.measurementlab.net"
   },
-  zones = {}
+  zones = {
+    "us-central1-a" = {
+      "create_role" = "init",
+      "reboot_day"  = "Tue"
+    },
+    "us-central1-b" = {
+      "create_role" = "join",
+      "reboot_day"  = "Wed"
+    },
+    "us-central1-c" = {
+      "create_role" = "join",
+      "reboot_day"  = "Thu"
+    }
+  }
 }
 
 prometheus_instance = {
-  disk_image        = "CHANGEME"
+  disk_image        = "platform-cluster-internal-instance-2023-05-30t21-35-06"
   disk_size_gb_boot = 100
   disk_size_gb_data = 1500
   disk_type         = "pd-ssd"
@@ -56,5 +82,21 @@ networking = {
     subnetwork_cidr = "10.0.0.0/8"
     vpc_name        = "mlab-platform-network"
   }
-  subnetworks = {}
+  subnetworks = {
+    "us-central1" = {
+      ip_cidr_range = "10.0.0.0/16"
+      name          = "kubernetes"
+      region        = "us-central1"
+    },
+    "us-east4" = {
+      ip_cidr_range = "10.2.0.0/16"
+      name          = "kubernetes"
+      region        = "us-east4"
+    },
+    "us-west2" = {
+      ip_cidr_range = "10.3.0.0/16"
+      name          = "kubernetes"
+      region        = "us-west2"
+    }
+  }
 }

--- a/modules/platform-cluster/instances.tf
+++ b/modules/platform-cluster/instances.tf
@@ -188,6 +188,7 @@ resource "google_compute_instance" "prometheus" {
     subnetwork = google_compute_subnetwork.platform_cluster[var.prometheus_instance.region].id
   }
 
+
   service_account {
     scopes = var.prometheus_instance.scopes
   }
@@ -214,5 +215,9 @@ resource "google_compute_disk" "prometheus_data_disk" {
   name = "prometheus-platform-cluster-${var.prometheus_instance.zone}"
   size = var.prometheus_instance.disk_size_gb_data
   type = var.prometheus_instance.disk_type
-  zone = var.prometheus_instance.zone
+  # This is only here to prevent the data disk in mlab-staging from needing to
+  # be replaced. For some reason the Prom data disk in staging has this set,
+  # even though the referenced snapshot doesn't even exist.
+  snapshot = var.project == "mlab-staging" ? "projects/mlab-staging/global/snapshots/prom-staging-snapshot" : null
+  zone     = var.prometheus_instance.zone
 }


### PR DESCRIPTION
The mlab-staging cluster is now fully under Terraform control, using the changes in this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/8)
<!-- Reviewable:end -->
