### PR TITLE
Changes to bring mlab-oti under Terraform control

### DIFF
--- a/assign_static_ipv6.sh
+++ b/assign_static_ipv6.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# A small shell script which will remove an ephemeral IPv6 address from an
+# instance and reassign a static IPv6 to the same instance. This is a temporary
+# helper script which will need to be run manually when instances are destroyed
+# and recreated. GCP supports static regional IPv6 addresses, but the Google
+# Terraform provider does not yet support this.
+
+set -euxo pipefail
+
+PROJECT=${1? The first argument must be the GCP project}
+
+shift
+
+for m in $@; do
+  machine="${m}-${PROJECT}-measurement-lab-org"
+  zone=$(
+	gcloud compute instances list --project $PROJECT --filter "name:$m" --format "value(zone)"
+  )
+
+  gcloud compute instances network-interfaces update $machine \
+    --network-interface=nic0 \
+	--stack-type=IPV4_ONLY \
+	--zone=$zone \
+	--project=$PROJECT
+
+  gcloud compute instances network-interfaces update $machine \
+    --network-interface=nic0 \
+	--ipv6-network-tier=PREMIUM \
+	--stack-type=IPV4_IPV6 \
+	--external-ipv6-address="${machine}-v6" \
+    --external-ipv6-prefix-length=96 \
+	--zone=$zone \
+	--project=$PROJECT
+done

--- a/mlab-oti/terraform.tfvars
+++ b/mlab-oti/terraform.tfvars
@@ -4,27 +4,169 @@ default_zone   = "us-east1-b"
 
 instances = {
   attributes = {
-    disk_image   = "CHANGEME"
+    disk_image   = "platform-cluster-instance-v2-4-1"
     disk_size_gb = 100
     disk_type    = "pd-ssd"
-    machine_type = "n1-highcpu-4"
+    machine_type = "n2-highcpu-4"
     network_tier = "PREMIUM"
     tags         = ["ndt-cloud"]
     scopes       = ["cloud-platform"]
   }
   migs = {}
-  vms  = {}
+  vms = {
+    mlab1-ams10 = {
+      zone = "europe-west4-c"
+    },
+    mlab1-bom03 = {
+      zone = "asia-south1-c"
+    },
+    mlab2-bom03 = {
+      zone = "asia-south1-b"
+    },
+    mlab3-bom03 = {
+      zone = "asia-south1-a"
+    },
+    mlab1-bru06 = {
+      zone = "europe-west1-c"
+    },
+    mlab1-cgk01 = {
+      zone = "asia-southeast2-c"
+    },
+    mlab1-chs01 = {
+      zone = "us-east1-c"
+    },
+    mlab2-chs01 = {
+      network_tier = "STANDARD"
+      zone         = "us-east1-b"
+    },
+    mlab1-cmh01 = {
+      zone = "us-east5-c"
+    },
+    mlab1-del03 = {
+      zone = "asia-south2-c"
+    },
+    mlab1-dfw09 = {
+      zone = "us-south1-c"
+    },
+    mlab1-fra07 = {
+      zone = "europe-west3-c"
+    },
+    mlab2-fra07 = {
+      zone = "europe-west3-b"
+    },
+    mlab1-gru05 = {
+      zone = "southamerica-east1-c"
+    },
+    mlab2-gru05 = {
+      zone = "southamerica-east1-b"
+    },
+    mlab3-gru05 = {
+      zone = "southamerica-east1-a"
+    },
+    mlab1-hel01 = {
+      zone = "europe-north1-c"
+    },
+    mlab1-hkg04 = {
+      zone = "asia-east2-c"
+    },
+    mlab1-hnd06 = {
+      zone = "asia-northeast1-c"
+    },
+    mlab2-hnd06 = {
+      zone = "asia-northeast1-b"
+    },
+    mlab3-hnd06 = {
+      zone = "asia-northeast1-a"
+    },
+    mlab1-iad07 = {
+      zone = "us-east4-c"
+    },
+    mlab2-iad07 = {
+      network_tier = "STANDARD"
+      zone         = "us-east4-b"
+    },
+    mlab1-icn01 = {
+      zone = "asia-northeast3-c"
+    },
+    mlab1-kix01 = {
+      zone = "asia-northeast2-c"
+    },
+    mlab1-las01 = {
+      zone = "us-west4-c"
+    },
+    mlab1-lax07 = {
+      zone = "us-west2-c"
+    },
+    mlab1-lhr09 = {
+      zone = "europe-west2-c"
+    },
+    mlab1-mad07 = {
+      zone = "europe-southwest1-c"
+    },
+    mlab1-mel01 = {
+      zone = "australia-southeast2-c"
+    },
+    mlab1-mil08 = {
+      zone = "europe-west8-c"
+    },
+    mlab1-oma01 = {
+      zone = "us-central1-c"
+    },
+    mlab1-par08 = {
+      zone = "europe-west9-c"
+    },
+    mlab1-pdx01 = {
+      zone = "us-west1-c"
+    },
+    mlab1-scl05 = {
+      zone = "southamerica-west1-c"
+    },
+    mlab1-sin02 = {
+      zone = "asia-southeast1-c"
+    },
+    mlab1-slc01 = {
+      zone = "us-west3-c"
+    },
+    mlab1-syd07 = {
+      zone = "australia-southeast1-c"
+    },
+    mlab1-tlv01 = {
+      zone = "me-west1-c"
+    },
+    mlab1-tpe02 = {
+      zone = "asia-east1-c"
+    },
+    mlab1-waw01 = {
+      zone = "europe-central2-c"
+    },
+    mlab2-waw01 = {
+      zone = "europe-central2-b"
+    },
+    mlab1-yul07 = {
+      zone = "northamerica-northeast1-c"
+    },
+    mlab2-yul07 = {
+      network_tier = "STANDARD"
+      zone         = "northamerica-northeast1-b"
+    },
+    mlab1-yyz07 = {
+      zone = "northamerica-northeast2-c"
+    },
+    mlab1-zrh01 = {
+      zone = "europe-west6-c"
+    }
+  }
 }
 
 api_instances = {
   machine_attributes = {
-    disk_image        = "CHANGEME"
+    disk_image        = "platform-cluster-api-instance-v2-4-1"
     disk_size_gb_boot = 100
     disk_size_gb_data = 10
     # This will show up as /dev/disk/by-id/google-<name>
     disk_dev_name_data = "cluster-data"
     disk_type          = "pd-ssd"
-    machine_type       = "n1-standard-2"
+    machine_type       = "n2-standard-8"
     tags               = ["platform-cluster"]
     region             = "us-east1"
     scopes             = ["cloud-platform"]
@@ -35,15 +177,28 @@ api_instances = {
     service_cidr           = "172.25.0.0/16"
     epoxy_extension_server = "epoxy-extension-server.mlab-oti.measurementlab.net"
   }
-  zones = {}
+  zones = {
+    "us-east1-b" = {
+      "create_role" = "init",
+      "reboot_day"  = "Tue"
+    },
+    "us-east1-c" = {
+      "create_role" = "join",
+      "reboot_day"  = "Wed"
+    },
+    "us-east1-d" = {
+      "create_role" = "join",
+      "reboot_day"  = "Thu"
+    }
+  }
 }
 
 prometheus_instance = {
-  disk_image        = "CHANGEME"
+  disk_image        = "platform-cluster-internal-instance-v2-4-1"
   disk_size_gb_boot = 100
   disk_size_gb_data = 3500
   disk_type         = "pd-ssd"
-  machine_type      = "e2-highmem-32"
+  machine_type      = "n2-highmem-32"
   tags              = ["prometheus-platform-cluster"]
   region            = "us-east1"
   scopes            = ["cloud-platform"]
@@ -56,5 +211,181 @@ networking = {
     subnetwork_cidr = "10.0.0.0/8"
     vpc_name        = "mlab-platform-network"
   }
-  subnetworks = {}
+  subnetworks = {
+    "asia-east1" = {
+      ip_cidr_range = "10.9.0.0/16"
+      name          = "kubernetes"
+      region        = "asia-east1"
+    },
+    "asia-east2" = {
+      ip_cidr_range = "10.18.0.0/16"
+      name          = "kubernetes"
+      region        = "asia-east2"
+    },
+    "asia-northeast1" = {
+      ip_cidr_range = "10.31.0.0/16"
+      name          = "kubernetes"
+      region        = "asia-northeast1"
+    },
+    "asia-northeast2" = {
+      ip_cidr_range = "10.22.0.0/16"
+      name          = "kubernetes"
+      region        = "asia-northeast2"
+    },
+    "asia-northeast3" = {
+      ip_cidr_range = "10.29.0.0/16"
+      name          = "kubernetes"
+      region        = "asia-northeast3"
+    },
+    "asia-south1" = {
+      ip_cidr_range = "10.24.0.0/16"
+      name          = "kubernetes"
+      region        = "asia-south1"
+    },
+    "asia-south2" = {
+      ip_cidr_range = "10.16.0.0/16"
+      name          = "kubernetes"
+      region        = "asia-south2"
+    },
+    "asia-southeast1" = {
+      ip_cidr_range = "10.11.0.0/16"
+      name          = "kubernetes"
+      region        = "asia-southeast1"
+    },
+    "asia-southeast2" = {
+      ip_cidr_range = "10.10.0.0/16"
+      name          = "kubernetes"
+      region        = "asia-southeast2"
+    },
+    "australia-southeast1" = {
+      ip_cidr_range = "10.30.0.0/16"
+      name          = "kubernetes"
+      region        = "australia-southeast1"
+    },
+    "australia-southeast2" = {
+      ip_cidr_range = "10.20.0.0/16"
+      name          = "kubernetes"
+      region        = "australia-southeast2"
+    },
+    "europe-central2" = {
+      ip_cidr_range = "10.33.0.0/16"
+      name          = "kubernetes"
+      region        = "europe-central2"
+    },
+    "europe-north1" = {
+      ip_cidr_range = "10.17.0.0/16"
+      name          = "kubernetes"
+      region        = "europe-north1"
+    },
+    "europe-southwest1" = {
+      ip_cidr_range = "10.19.0.0/16"
+      name          = "kubernetes"
+      region        = "europe-southwest1"
+    },
+    "europe-west1" = {
+      ip_cidr_range = "10.6.0.0/16"
+      name          = "kubernetes"
+      region        = "europe-west1"
+    },
+    "europe-west2" = {
+      ip_cidr_range = "10.7.0.0/16"
+      name          = "kubernetes"
+      region        = "europe-west2"
+    },
+    "europe-west3" = {
+      ip_cidr_range = "10.8.0.0/16"
+      name          = "kubernetes"
+      region        = "europe-west3"
+    },
+    "europe-west4" = {
+      ip_cidr_range = "10.13.0.0/16"
+      name          = "kubernetes"
+      region        = "europe-west4"
+    },
+    "europe-west6" = {
+      ip_cidr_range = "10.34.0.0/16"
+      name          = "kubernetes"
+      region        = "europe-west6"
+    },
+    "europe-west8" = {
+      ip_cidr_range = "10.21.0.0/16"
+      name          = "kubernetes"
+      region        = "europe-west8"
+    },
+    "europe-west9" = {
+      ip_cidr_range = "10.25.0.0/16"
+      name          = "kubernetes"
+      region        = "europe-west9"
+    },
+    "me-west1" = {
+      ip_cidr_range = "10.35.0.0/16"
+      name          = "kubernetes"
+      region        = "me-west1"
+    },
+    "northamerica-northeast1" = {
+      ip_cidr_range = "10.23.0.0/16"
+      name          = "kubernetes"
+      region        = "northamerica-northeast1"
+    }
+    "northamerica-northeast2" = {
+      ip_cidr_range = "10.32.0.0/16"
+      name          = "kubernetes"
+      region        = "northamerica-northeast2"
+    },
+    "southamerica-east1" = {
+      ip_cidr_range = "10.28.0.0/16",
+      name          = "kubernetes"
+      region        = "southamerica-east1"
+    },
+    "southamerica-west1" = {
+      ip_cidr_range = "10.27.0.0/16"
+      name          = "kubernetes"
+      region        = "southamerica-west1"
+    },
+    "us-central1" = {
+      ip_cidr_range = "10.3.0.0/16"
+      name          = "kubernetes"
+      region        = "us-central1"
+    },
+    "us-east1" = {
+      ip_cidr_range = "10.0.0.0/16"
+      name          = "kubernetes"
+      region        = "us-east1"
+    },
+    "us-east4" = {
+      ip_cidr_range = "10.2.0.0/16"
+      name          = "kubernetes"
+      region        = "us-east4"
+    },
+    "us-east5" = {
+      ip_cidr_range = "10.14.0.0/16"
+      name          = "kubernetes"
+      region        = "us-east5"
+    },
+    "us-south1" = {
+      ip_cidr_range = "10.15.0.0/16"
+      name          = "kubernetes"
+      region        = "us-south1"
+    },
+    "us-west1" = {
+      ip_cidr_range = "10.4.0.0/16"
+      name          = "kubernetes"
+      region        = "us-west1"
+    }
+    "us-west2" = {
+      ip_cidr_range = "10.5.0.0/16"
+      name          = "kubernetes"
+      region        = "us-west2"
+    },
+    "us-west3" = {
+      ip_cidr_range = "10.26.0.0/16"
+      name          = "kubernetes"
+      region        = "us-west3"
+    },
+    "us-west4" = {
+      ip_cidr_range = "10.12.0.0/16"
+      name          = "kubernetes"
+      region        = "us-west4"
+    }
+  }
 }

--- a/modules/platform-cluster/instances.tf
+++ b/modules/platform-cluster/instances.tf
@@ -215,9 +215,12 @@ resource "google_compute_disk" "prometheus_data_disk" {
   name = "prometheus-platform-cluster-${var.prometheus_instance.zone}"
   size = var.prometheus_instance.disk_size_gb_data
   type = var.prometheus_instance.disk_type
-  # This is only here to prevent the data disk in mlab-staging from needing to
-  # be replaced. For some reason the Prom data disk in staging has this set,
-  # even though the referenced snapshot doesn't even exist.
-  snapshot = var.project == "mlab-staging" ? "projects/mlab-staging/global/snapshots/prom-staging-snapshot" : null
+  # For some reason the staging and production disk have this set, even though
+  # the referenced snapshots don't even exist. This is added here just to
+  # prevent Terraform from deleting and recreating the production disk, causing
+  # all metrics to be lost. Sadly, the snapshots in staging and production have
+  # slightly different names, making it hard to preserve both programatically in
+  # Terraform. We'll preserve the production disk.
+  snapshot = "projects/${var.project}/global/snapshots/prom-snapshot-oti"
   zone     = var.prometheus_instance.zone
 }

--- a/modules/platform-cluster/loadbalancers.tf
+++ b/modules/platform-cluster/loadbalancers.tf
@@ -90,7 +90,6 @@ resource "google_compute_forwarding_rule" "platform_cluster" {
   region          = var.api_instances.machine_attributes.region
 }
 
-
 #
 # Internal load balancer for the ePoxy extension server. The
 # extension server service runs on each of the control plane nodes.


### PR DESCRIPTION
This commit implements the configs to manage the mlab-oti platform cluster. It also adds a small helper shell script to assist with assigning static IPv6 addresses to machines.