### PR TITLE
Adds two new VMs to virtual site dfw09

### DIFF
--- a/mlab-oti/terraform.tfvars
+++ b/mlab-oti/terraform.tfvars
@@ -48,6 +48,12 @@ instances = {
     mlab1-dfw09 = {
       zone = "us-south1-c"
     },
+    mlab2-dfw09 = {
+      zone = "us-south1-b"
+    },
+    mlab3-dfw09 = {
+      zone = "us-south1-a"
+    },
     mlab1-fra07 = {
       zone = "europe-west3-c"
     },

--- a/mlab-sandbox/terraform.tfvars
+++ b/mlab-sandbox/terraform.tfvars
@@ -4,7 +4,7 @@ default_zone   = "us-west2-a"
 
 instances = {
   attributes = {
-    disk_image   = "platform-cluster-instance-2023-06-02t22-30-03"
+    disk_image   = "platform-cluster-instance-2023-06-22t18-13-01"
     disk_size_gb = 100
     disk_type    = "pd-ssd"
     machine_type = "n1-highcpu-4"
@@ -32,7 +32,7 @@ instances = {
 
 api_instances = {
   machine_attributes = {
-    disk_image        = "platform-cluster-api-instance-2023-06-02t22-30-03"
+    disk_image        = "platform-cluster-api-instance-2023-06-22t18-13-01"
     disk_size_gb_boot = 100
     disk_size_gb_data = 10
     # This will show up as /dev/disk/by-id/google-<name>
@@ -66,7 +66,7 @@ api_instances = {
 }
 
 prometheus_instance = {
-  disk_image        = "platform-cluster-internal-instance-2023-06-02t22-30-03"
+  disk_image        = "platform-cluster-internal-instance-2023-06-22t18-13-01"
   disk_size_gb_boot = 100
   disk_size_gb_data = 200
   disk_type         = "pd-ssd"

--- a/modules/platform-cluster/instances.tf
+++ b/modules/platform-cluster/instances.tf
@@ -221,6 +221,6 @@ resource "google_compute_disk" "prometheus_data_disk" {
   # all metrics to be lost. Sadly, the snapshots in staging and production have
   # slightly different names, making it hard to preserve both programatically in
   # Terraform. We'll preserve the production disk.
-  snapshot = "projects/${var.project}/global/snapshots/prom-snapshot-oti"
+  snapshot = var.project == "mlab-oti" ? "projects/${var.project}/global/snapshots/prom-snapshot-oti" : null
   zone     = var.prometheus_instance.zone
 }


### PR DESCRIPTION
In an attempt to help spread DFW traffic among more machines, this PR adds two new VMs to the virtual site DFW09.

Additionally, Locate was updated to give dfw09 full probability of being selected.

One other change in the PR applies (for now) only to mlab-sandbox. It updates the boot images for all machines with updated k8s components at v1.24.15. The changes have already been applied to the sandbox cluster.

One other small fix in this PR is to use a TF ternary operator to apply the snapshot field to the production instance of the Prometheus data disk, thus preventing TF from wanting to destroy and recreate the disk, causing all production metrics to vanish. On the other hand, metrics in sandbox and staging will go away when applied to those clusters. One possible workaround for this might be to temporarily stop the mlab-oti instance of Prometheus, backup the metric data, let TF recreate the data disk without the "snapshot" setting, restore the metric data, then restart Prometheus. This would entail some calculate amount of downtime of the production instance of Prometheus.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/10)
<!-- Reviewable:end -->
