### PR TITLE
k8s v1.24.15 + new local-exec provisioner for instances

### DIFF
--- a/assign_static_ipv6.sh
+++ b/assign_static_ipv6.sh
@@ -38,6 +38,10 @@ for m in $@; do
 	  --project $PROJECT
   fi
 
+  # This step effectively removes the ephemeral IPv6 address of the machine by
+  # specifying IPV4_ONLY. After which we add the existing static IPv6 address.
+  # This way of doing things comes directly from the Google documentation:
+  # https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address#IP_assign
   gcloud compute instances network-interfaces update $machine \
     --network-interface=nic0 \
 	--stack-type=IPV4_ONLY \

--- a/mlab-sandbox/terraform.tfvars
+++ b/mlab-sandbox/terraform.tfvars
@@ -4,7 +4,7 @@ default_zone   = "us-west2-a"
 
 instances = {
   attributes = {
-    disk_image       = "platform-cluster-instance-2023-06-29t23-16-02"
+    disk_image       = "platform-cluster-instance-2023-07-10t17-43-10",
     disk_size_gb     = 100
     disk_type        = "pd-ssd"
     machine_type     = "n2-highcpu-4"
@@ -34,7 +34,7 @@ instances = {
 
 api_instances = {
   machine_attributes = {
-    disk_image        = "platform-cluster-api-instance-2023-06-29t23-16-02"
+    disk_image        = "platform-cluster-api-instance-2023-07-10t17-43-10",
     disk_size_gb_boot = 100
     disk_size_gb_data = 10
     # This will show up as /dev/disk/by-id/google-<name>
@@ -68,7 +68,7 @@ api_instances = {
 }
 
 prometheus_instance = {
-  disk_image        = "platform-cluster-internal-instance-2023-06-29t23-16-02"
+  disk_image        = "platform-cluster-internal-instance-2023-07-10t17-43-10",
   disk_size_gb_boot = 100
   disk_size_gb_data = 200
   disk_type         = "pd-ssd"

--- a/mlab-staging/terraform.tfvars
+++ b/mlab-staging/terraform.tfvars
@@ -4,7 +4,7 @@ default_zone   = "us-central1-a"
 
 instances = {
   attributes = {
-    disk_image       = "platform-cluster-instance-2023-06-05t17-31-28"
+    disk_image       = "platform-cluster-instance-2023-07-10t22-28-33"
     disk_size_gb     = 100
     disk_type        = "pd-ssd"
     machine_type     = "n2-highcpu-4"
@@ -33,7 +33,7 @@ instances = {
 
 api_instances = {
   machine_attributes = {
-    disk_image        = "platform-cluster-api-instance-2023-06-05t17-31-28"
+    disk_image        = "platform-cluster-api-instance-2023-07-10t22-28-33"
     disk_size_gb_boot = 100
     disk_size_gb_data = 10
     # This will show up as /dev/disk/by-id/google-<name>
@@ -67,7 +67,7 @@ api_instances = {
 }
 
 prometheus_instance = {
-  disk_image        = "platform-cluster-internal-instance-2023-06-05t17-31-28"
+  disk_image        = "platform-cluster-internal-instance-2023-07-10t22-28-33"
   disk_size_gb_boot = 100
   disk_size_gb_data = 1500
   disk_type         = "pd-ssd"

--- a/modules/platform-cluster/instances.tf
+++ b/modules/platform-cluster/instances.tf
@@ -126,6 +126,14 @@ resource "google_compute_instance" "platform_instances" {
     subnetwork = google_compute_subnetwork.platform_cluster[regex("^([a-z]+-[a-z0-9]+)-[a-z]$", each.value["zone"])[0]].id
   }
 
+  # Removes the empheral IPv6 address created by the Terraform deployment and
+  # replaces it with a static address. Today, GCP supports static, regional,
+  # external IPv6 addresses, but the Google Terraform provider does not.
+  # TODO(kinkade): remove this once the Google provider catches up to GCP.
+  provisioner "local-exec" {
+    command = "../assign_static_ipv6.sh ${var.project} ${each.key}"
+  }
+
   service_account {
     scopes = var.instances.attributes.scopes
   }


### PR DESCRIPTION
This PR updates the boot disk source image to one that contains the k8s v1.24.15 components.

Additionally, it add a new `local-exec` provisioner to instance configurations. GCP supports static, regional, external IPv6 addresses, but the Google Terraform provider does not yet support this feature. This commit adds a local-exec provisioner to instances which will remove the ephemeral external IPv6 from and instance and replace it with a static one. If this is a new VM and the static address does not already exist, it will create it. This is a workaround to keep our VM IPv6 configs in sync with
DNS created by siteinfo.

The script already existed in the repo, but previously was not run automatically for each instance, nor would it create the static IPv6 address if it didn't exist. This should be a viable workaround until the Google provider catches up to GCP. It seems this feature was added to a "Goals"  milestone back in late May:

https://github.com/hashicorp/terraform-provider-google/issues/14748

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/12)
<!-- Reviewable:end -->
