### PR TITLE
Adds auto_delete=false to instance boot disks

### DIFF
--- a/modules/platform-cluster/instances.tf
+++ b/modules/platform-cluster/instances.tf
@@ -13,7 +13,8 @@ resource "google_compute_instance" "api_instances" {
   }
 
   boot_disk {
-    source = google_compute_disk.api_boot_disks[each.key].id
+    auto_delete = false
+    source      = google_compute_disk.api_boot_disks[each.key].id
   }
 
   hostname = "api-platform-cluster-${each.key}.${var.project}.measurementlab.net"
@@ -91,7 +92,8 @@ resource "google_compute_instance" "platform_instances" {
   allow_stopping_for_update = true
 
   boot_disk {
-    source = google_compute_disk.platform_boot_disks["${each.key}"].id
+    auto_delete = false
+    source      = google_compute_disk.platform_boot_disks["${each.key}"].id
   }
 
   description  = "Platform VMs that are not part of a MIG"
@@ -181,7 +183,8 @@ resource "google_compute_instance" "prometheus" {
   }
 
   boot_disk {
-    source = google_compute_disk.prometheus_boot_disk.id
+    auto_delete = false
+    source      = google_compute_disk.prometheus_boot_disk.id
   }
 
   machine_type = var.prometheus_instance.machine_type


### PR DESCRIPTION
This setting wasn't needed when Terraform was allowed to do everything it wanted to do with regard to instances. However, when wrapping TF in a small shell script to update instances one at a time, TF would delete the VM and the boot disk would get automatically deleted by GCP. When TF would go to recreate the instance, it would complain that the reference boot disk didn't exist, which was true. This should prevent GCP from auto-deleting the boot disk when a VM gets deleted, which should prevent this problem.