### PR TITLE
Updates API instance image + adds 2 new virtual sites

### DIFF
--- a/mlab-oti/terraform.tfvars
+++ b/mlab-oti/terraform.tfvars
@@ -59,6 +59,9 @@ instances = {
     mlab3-dfw09 = {
       zone = "us-south1-a"
     },
+    mlab1-doh01 = {
+      zone = "me-central1-c"
+    },
     mlab1-fra07 = {
       zone = "europe-west3-c"
     },
@@ -161,6 +164,9 @@ instances = {
     },
     mlab2-tpe02 = {
       zone = "asia-east1-b"
+    },
+    mlab1-trn03 = {
+      zone = "europe-west12-c"
     },
     mlab1-waw01 = {
       zone = "europe-central2-c"

--- a/mlab-sandbox/terraform.tfvars
+++ b/mlab-sandbox/terraform.tfvars
@@ -34,7 +34,7 @@ instances = {
 
 api_instances = {
   machine_attributes = {
-    disk_image        = "platform-cluster-api-instance-2023-07-28t17-41-18"
+    disk_image        = "platform-cluster-api-instance-2023-08-01t16-27-12"
     disk_size_gb_boot = 100
     disk_size_gb_data = 10
     # This will show up as /dev/disk/by-id/google-<name>

--- a/mlab-staging/terraform.tfvars
+++ b/mlab-staging/terraform.tfvars
@@ -33,7 +33,7 @@ instances = {
 
 api_instances = {
   machine_attributes = {
-    disk_image        = "platform-cluster-api-instance-2023-07-27t22-18-21"
+    disk_image        = "platform-cluster-api-instance-2023-08-01t17-40-45"
     disk_size_gb_boot = 100
     disk_size_gb_data = 10
     # This will show up as /dev/disk/by-id/google-<name>


### PR DESCRIPTION
Updates the API instance image in sandbox to a version that includes the new epoxy-extension-server version.

Adds 2 new virtual sites for recently deployed Google regions in Turin, Italy and Doha, Qatar.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/17)
<!-- Reviewable:end -->
