### PR TITLE
Add third Indonesian VM

### DIFF
--- a/mlab-oti/terraform.tfvars
+++ b/mlab-oti/terraform.tfvars
@@ -37,6 +37,9 @@ instances = {
     mlab2-cgk01 = {
       zone = "asia-southeast2-b"
     },
+    mlab3-cgk01 = {
+      zone = "asia-southeast2-a"
+    },
     mlab1-chs01 = {
       zone = "us-east1-c"
     },


### PR DESCRIPTION
cgk is the last remaining cloud site held at a probability less than 1.0. As part of https://github.com/m-lab/ops-tracker/issues/1796 this change adds a third VM for cgk01.