### PR TITLE
Google won't give us any N2_CPUs in region

### DIFF
--- a/mlab-oti/terraform.tfvars
+++ b/mlab-oti/terraform.tfvars
@@ -62,9 +62,6 @@ instances = {
     mlab3-dfw09 = {
       zone = "us-south1-a"
     },
-    mlab1-doh01 = {
-      zone = "me-central1-c"
-    },
     mlab1-fra07 = {
       zone = "europe-west3-c"
     },
@@ -365,11 +362,6 @@ networking = {
       ip_cidr_range = "10.37.0.0/16"
       name          = "kubernetes"
       region        = "europe-west12"
-    },
-    "me-central1" = {
-      ip_cidr_range = "10.36.0.0/16"
-      name          = "kubernetes"
-      region        = "me-central1"
     },
     "me-west1" = {
       ip_cidr_range = "10.35.0.0/16"


### PR DESCRIPTION
We started with a request for an increase from a quota of 0 to 12, which was rejected. I submitted a new quota adjustment request, asking for only 4, which was also rejected. Since our default VM type n2-highcpu-4 requires 4 N2_CPUs, we cannot currently support this region.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/21)
<!-- Reviewable:end -->
