### PR TITLE
Updates staging and prod VM boot disk images

### DIFF
--- a/mlab-oti/terraform.tfvars
+++ b/mlab-oti/terraform.tfvars
@@ -4,7 +4,7 @@ default_zone   = "us-east1-b"
 
 instances = {
   attributes = {
-    disk_image       = "platform-cluster-instance-v2-4-4"
+    disk_image       = "platform-cluster-instance-v2-4-5"
     disk_size_gb     = 100
     disk_type        = "pd-ssd"
     machine_type     = "n2-highcpu-4"
@@ -201,7 +201,7 @@ instances = {
 
 api_instances = {
   machine_attributes = {
-    disk_image        = "platform-cluster-api-instance-v2-4-4"
+    disk_image        = "platform-cluster-api-instance-v2-4-5"
     disk_size_gb_boot = 100
     disk_size_gb_data = 10
     # This will show up as /dev/disk/by-id/google-<name>
@@ -235,7 +235,7 @@ api_instances = {
 }
 
 prometheus_instance = {
-  disk_image        = "platform-cluster-internal-instance-v2-4-4"
+  disk_image        = "platform-cluster-internal-instance-v2-4-5"
   disk_size_gb_boot = 100
   disk_size_gb_data = 3500
   disk_type         = "pd-ssd"

--- a/mlab-staging/terraform.tfvars
+++ b/mlab-staging/terraform.tfvars
@@ -4,7 +4,7 @@ default_zone   = "us-central1-a"
 
 instances = {
   attributes = {
-    disk_image       = "platform-cluster-instance-2023-07-27t22-18-21"
+    disk_image       = "platform-cluster-instance-2023-08-01t17-40-45"
     disk_size_gb     = 100
     disk_type        = "pd-ssd"
     machine_type     = "n2-highcpu-4"
@@ -67,7 +67,7 @@ api_instances = {
 }
 
 prometheus_instance = {
-  disk_image        = "platform-cluster-internal-instance-2023-07-27t22-18-21"
+  disk_image        = "platform-cluster-internal-instance-2023-08-01t17-40-45"
   disk_size_gb_boot = 100
   disk_size_gb_data = 1500
   disk_type         = "pd-ssd"


### PR DESCRIPTION
In staging, the boot disk for normal platform instances and the prometheus instance are updated to contain the latest leave-cluster.sh script. In mlab-oti, the disks for all VMs are updated to v2.4.5, which includes the updated epoxy-extension-server on API images, and updated leave-cluster.sh scripts for other VMs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/22)
<!-- Reviewable:end -->
