### PR TITLE
Adds dfw09 MIGs in staging and production

### DIFF
--- a/mlab-oti/terraform.tfvars
+++ b/mlab-oti/terraform.tfvars
@@ -14,7 +14,11 @@ instances = {
     tags             = ["ndt-cloud"]
     scopes           = ["cloud-platform"]
   }
-  migs = {}
+  migs = {
+    mlab3-dfw09 = {
+      zone = "us-south1-a"
+    }
+  }
   vms = {
     mlab1-ams10 = {
       zone = "europe-west4-c"
@@ -58,9 +62,6 @@ instances = {
     },
     mlab2-dfw09 = {
       zone = "us-south1-b"
-    },
-    mlab3-dfw09 = {
-      zone = "us-south1-a"
     },
     mlab1-fra07 = {
       zone = "europe-west3-c"

--- a/mlab-staging/terraform.tfvars
+++ b/mlab-staging/terraform.tfvars
@@ -14,7 +14,11 @@ instances = {
     tags             = ["ndt-cloud"]
     scopes           = ["cloud-platform"]
   },
-  migs = {},
+  migs = {
+    mlab4-dfw09 = {
+      zone = "us-south1-c"
+    }
+  },
   vms = {
     mlab3-iad08 = {
       zone = "us-east4-c"


### PR DESCRIPTION
Adds a new MIG named mlab4-dfw09 in staging, and replaces the standalone production VM mlab3-dfw09 with a MIG of the same name.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/23)
<!-- Reviewable:end -->
