### PR TITLE
Adds subnetwork for us-south1 region

### DIFF
--- a/mlab-staging/terraform.tfvars
+++ b/mlab-staging/terraform.tfvars
@@ -103,6 +103,11 @@ networking = {
       ip_cidr_range = "10.3.0.0/16"
       name          = "kubernetes"
       region        = "us-west2"
+    },
+    "us-south1" = {
+      ip_cidr_range = "10.4.0.0/16"
+      name          = "kubernetes"
+      region        = "us-south1"
     }
   }
 }


### PR DESCRIPTION
I failed to add this required entry when I added the new MIG mlab4-dfw09.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/24)
<!-- Reviewable:end -->
