### PR TITLE
Corrects MIG field from zone to region

### DIFF
--- a/mlab-staging/terraform.tfvars
+++ b/mlab-staging/terraform.tfvars
@@ -16,7 +16,7 @@ instances = {
   },
   migs = {
     mlab4-dfw09 = {
-      zone = "us-south1-c"
+      region = "us-south1"
     }
   },
   vms = {


### PR DESCRIPTION
The field in a MIG definition, unlike for regular VMs, is not "zone", but "region".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/25)
<!-- Reviewable:end -->
