### PR TITLE
Removes max_surge_fixes from MIG update_policy

### DIFF
--- a/modules/platform-cluster/instancegroups.tf
+++ b/modules/platform-cluster/instancegroups.tf
@@ -73,9 +73,8 @@ resource "google_compute_region_instance_group_manager" "platform_cluster_mig_ma
   region             = each.value["region"]
 
   update_policy {
-    max_surge_fixed = length(var.instances.migs)
-    minimal_action  = "REPLACE"
-    type            = "PROACTIVE"
+    minimal_action = "REPLACE"
+    type           = "PROACTIVE"
   }
 
   version {


### PR DESCRIPTION
The field is optional, and must be 0 or equal to the number of zones the MIG is configured to use. Rather than trying to guess this or add a fixed value, just let it update however it wants.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/26)
<!-- Reviewable:end -->
