### PR TITLE
Add default location to all projects

### DIFF
--- a/mlab-oti/main.tf
+++ b/mlab-oti/main.tf
@@ -18,6 +18,7 @@ module "platform-cluster" {
   project             = var.project
   default_region      = var.default_region
   default_zone        = var.default_zone
+  default_location    = var.default_location
   instances           = var.instances
   api_instances       = var.api_instances
   prometheus_instance = var.prometheus_instance

--- a/mlab-oti/terraform.tfvars
+++ b/mlab-oti/terraform.tfvars
@@ -1,6 +1,7 @@
 project        = "mlab-oti"
 default_region = "us-east1"
 default_zone   = "us-east1-b"
+default_location = "us-central1"
 
 instances = {
   attributes = {

--- a/mlab-staging/main.tf
+++ b/mlab-staging/main.tf
@@ -18,6 +18,7 @@ module "platform-cluster" {
   project             = var.project
   default_region      = var.default_region
   default_zone        = var.default_zone
+  default_location    = var.default_location
   instances           = var.instances
   api_instances       = var.api_instances
   prometheus_instance = var.prometheus_instance

--- a/mlab-staging/terraform.tfvars
+++ b/mlab-staging/terraform.tfvars
@@ -1,6 +1,7 @@
 project        = "mlab-staging"
 default_region = "us-central1"
 default_zone   = "us-central1-a"
+default_location = "us-central1"
 
 instances = {
   attributes = {


### PR DESCRIPTION
This change corrects a bug introduced in https://github.com/m-lab/terraform-support/pull/29 that added a new variable for default_location but failed to set the value in mlab-staging and mlab-oti configurations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/30)
<!-- Reviewable:end -->
