### PR TITLE
Update min/max node counts for parser and prometheus

### DIFF
--- a/modules/data-pipeline/data-pipeline-node-pools.tf
+++ b/modules/data-pipeline/data-pipeline-node-pools.tf
@@ -56,7 +56,7 @@ resource "google_container_node_pool" "parser" {
   }
 
   autoscaling {
-    max_node_count = 2
+    max_node_count = 3
     min_node_count = 0
   }
   upgrade_settings {
@@ -120,7 +120,7 @@ resource "google_container_node_pool" "prometheus" {
 
   autoscaling {
     max_node_count = 2
-    min_node_count = 1
+    min_node_count = 0
   }
   upgrade_settings {
     max_surge       = 1


### PR DESCRIPTION
This change updates the min or max node counts used by the parser and prometheus node pools in the new data-pipeline cluster. The parser default prevented 8 nodes from being created for all parsers, and the prometheus default required wasted nodes. Ideally we want one spare, but two spares is a waste.

Part of:
* https://github.com/m-lab/etl/issues/1092

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/31)
<!-- Reviewable:end -->
