### PR TITLE
Add data-pipeline configuration for production

### DIFF
--- a/mlab-oti/.terraform.lock.hcl
+++ b/mlab-oti/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/google" {
   constraints = "4.64.0"
   hashes = [
     "h1:e9YVOqH5JQTR0LbT+VkOlJb1pDoZEvzXkqaA0Xsn5Mo=",
+    "h1:fA1kuAkOfuDLSdpcyKpeBPZinyPWLpmzBcRyNiaSxYc=",
     "zh:097fcb0a45fa41c2476deeb7a9adeadf5142e35e4d1a9eeb7b1720900a06807c",
     "zh:177e6e34f10efb5cec16b4106af5aef5240f20c33d91d40f3ea73fdc6ce9a24a",
     "zh:3331b0f62f900f8f1447e654a7318f3db03723739ac5dcdc446f1a1b1bf5fd0b",

--- a/mlab-oti/main.tf
+++ b/mlab-oti/main.tf
@@ -25,3 +25,10 @@ module "platform-cluster" {
   networking          = var.networking
   ssh_keys            = var.ssh_keys
 }
+
+module "data-pipeline" {
+  source = "../modules/data-pipeline"
+
+  project = var.project
+  default_location = var.default_location
+}


### PR DESCRIPTION
This change adds the data pipeline configuration for mlab-oti. 

Note: the platform cluster changes to production have not yet been deployed so include many changes.

Part of:
* https://github.com/m-lab/etl/issues/1092

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/34)
<!-- Reviewable:end -->
