### PR TITLE
Add static external IP address for ingress-nginx to data-pipeline module

### DIFF
--- a/modules/data-pipeline/data-pipeline.tf
+++ b/modules/data-pipeline/data-pipeline.tf
@@ -29,7 +29,7 @@ resource "google_container_cluster" "data_pipeline" {
 }
 
 resource "google_compute_address" "data_pipeline" {
-  name		= "ingress-nginx"
+  name		= "data-pipeline-ingress-nginx"
   address_type 	= "EXTERNAL"
   description	= "External IP address for ingress-nginx"
 }

--- a/modules/data-pipeline/data-pipeline.tf
+++ b/modules/data-pipeline/data-pipeline.tf
@@ -6,18 +6,18 @@ resource "google_compute_network" "data_pipeline" {
 }
 
 resource "google_compute_subnetwork" "data_pipeline" {
-  ip_cidr_range              = "10.80.0.0/16"
-  name                       = "pipeline"
-  network                    = google_compute_network.data_pipeline.id
-  region                     = data.google_client_config.current.region
+  ip_cidr_range = "10.80.0.0/16"
+  name          = "pipeline"
+  network       = google_compute_network.data_pipeline.id
+  region        = data.google_client_config.current.region
 }
 
 resource "google_container_cluster" "data_pipeline" {
 
-  name      = "data-pipeline"
-  location  = data.google_client_config.current.region
+  name     = "data-pipeline"
+  location = data.google_client_config.current.region
 
-  network = google_compute_network.data_pipeline.id
+  network    = google_compute_network.data_pipeline.id
   subnetwork = google_compute_subnetwork.data_pipeline.id
 
   remove_default_node_pool = true
@@ -29,7 +29,7 @@ resource "google_container_cluster" "data_pipeline" {
 }
 
 resource "google_compute_address" "data_pipeline" {
-  name		= "data-pipeline-ingress-nginx"
-  address_type 	= "EXTERNAL"
-  description	= "External IP address for ingress-nginx"
+  address_type = "EXTERNAL"
+  description  = "External IP address for ingress-nginx"
+  name         = "data-pipeline-ingress-nginx"
 }

--- a/modules/data-pipeline/data-pipeline.tf
+++ b/modules/data-pipeline/data-pipeline.tf
@@ -27,3 +27,9 @@ resource "google_container_cluster" "data_pipeline" {
     data-pipeline = "true"
   }
 }
+
+resource "google_compute_address" "data_pipeline" {
+  name		= "ingress-nginx"
+  address_type 	= "EXTERNAL"
+  description	= "External IP address for ingress-nginx"
+}


### PR DESCRIPTION
Brings ingress-nginx's static external IP address for the data-pipeline cluster under Terraform's control. Please let me know if this isn't the right way to do it. :slightly_smiling_face: 

(Note that I let Terraform re-create the external IP reservation from scratch because I could not find how to import the existing one. Since the only PR where this IP is used is still pending, I've just updated it with the new addresses.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/37)
<!-- Reviewable:end -->
