### PR TITLE
Adds new "daemonset" variable

### DIFF
--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -7,6 +7,7 @@ module "platform-cluster" {
 
   instances = {
     attributes = {
+      daemonset        = "ndt"
       disk_image       = "platform-cluster-instance-v2-4-5"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
@@ -17,7 +18,12 @@ module "platform-cluster" {
       tags             = ["ndt-cloud"]
       scopes           = ["cloud-platform"]
     }
-    migs = {}
+    migs = {
+      mlab3-dfw09 = {
+        daemonset = "ndt-canary"
+        region    = "us-south1"
+      }
+    }
     vms = {
       mlab1-ams10 = {
         zone = "europe-west4-c"
@@ -61,9 +67,6 @@ module "platform-cluster" {
       },
       mlab2-dfw09 = {
         zone = "us-south1-b"
-      },
-      mlab3-dfw09 = {
-        zone = "us-south1-a"
       },
       mlab1-fra07 = {
         zone = "europe-west3-c"

--- a/mlab-sandbox/platform-cluster.tf
+++ b/mlab-sandbox/platform-cluster.tf
@@ -7,6 +7,7 @@ module "platform-cluster" {
 
   instances = {
     attributes = {
+      daemonset        = "ndt"
       disk_image       = "platform-cluster-instance-2023-08-29t22-05-18"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
@@ -22,7 +23,8 @@ module "platform-cluster" {
         region = "us-east1"
       },
       mlab1-lax0t = {
-        region = "us-west2"
+        daemonset = "ndt-canary"
+        region    = "us-west2"
       },
       mlab1-pdx0t = {
         region = "us-west1"

--- a/mlab-staging/platform-cluster.tf
+++ b/mlab-staging/platform-cluster.tf
@@ -7,6 +7,7 @@ module "platform-cluster" {
 
   instances = {
     attributes = {
+      daemonset        = "ndt"
       disk_image       = "platform-cluster-instance-2023-08-01t17-40-45"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"

--- a/modules/platform-cluster/instancegroups.tf
+++ b/modules/platform-cluster/instancegroups.tf
@@ -25,7 +25,7 @@ resource "google_compute_instance_template" "platform_cluster_mig_templates" {
       "mlab/machine=${split("-", each.key)[0]}",
       "mlab/metro=${substr(each.key, 6, 3)}",
       "mlab/project=${data.google_client_config.current.project}",
-      "mlab/run=ndt",
+      "mlab/run=${lookup(each.value, "daemonset", var.instances.attributes.daemonset)}",
       "mlab/site=${split("-", each.key)[1]}",
       "mlab/type=virtual"
     ])

--- a/modules/platform-cluster/instances.tf
+++ b/modules/platform-cluster/instances.tf
@@ -117,7 +117,7 @@ resource "google_compute_instance" "platform_instances" {
       "mlab/machine=${split("-", each.key)[0]}",
       "mlab/metro=${substr(each.key, 6, 3)}",
       "mlab/project=${data.google_client_config.current.project}",
-      "mlab/run=ndt",
+      "mlab/run=${lookup(each.value, "daemonset", var.instances.attributes.daemonset)}",
       "mlab/site=${split("-", each.key)[1]}",
       "mlab/type=virtual"
     ])

--- a/modules/platform-cluster/variables.tf
+++ b/modules/platform-cluster/variables.tf
@@ -2,6 +2,7 @@ variable "instances" {
   description = "Platform instances"
   type = object({
     attributes = object({
+      daemonset        = string
       disk_image       = string
       disk_size_gb     = number
       disk_type        = string


### PR DESCRIPTION
Today, the ndt-virtual DaemonSet's nodeSelectors are `mlab/run=ndt, mlab/type=virtual`, and the `mlab/run=ndt` label is statically applied to every platform virtual machine. This PR introduces a new instance attribute named `daemonset=ndt`, which can be overridden in each individual instance of MIG definition, if we want it to run something other than the ndt-virtual DaemonSet. The specific motivation for this feature is the ability to run the ndt-canary DaemonSet on a VM or MIG instance. I will change the ndt-canary DaemonSet's nodeSelectors to `mlab/run=ndt-canary, mlab/type=virtual`.
.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/38)
<!-- Reviewable:end -->
