### PR TITLE
Remove test MIG from production

### DIFF
--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -64,6 +64,9 @@ module "platform-cluster" {
       mlab2-dfw09 = {
         zone = "us-south1-b"
       },
+      mlab3-dfw09 = {
+        zone = "us-south1-a"
+      },
       mlab1-fra07 = {
         zone = "europe-west3-c"
       },

--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -18,12 +18,7 @@ module "platform-cluster" {
       tags             = ["ndt-cloud"]
       scopes           = ["cloud-platform"]
     }
-    migs = {
-      mlab3-dfw09 = {
-        daemonset = "ndt-canary"
-        region    = "us-south1"
-      }
-    }
+    migs = {}
     vms = {
       mlab1-ams10 = {
         zone = "europe-west4-c"


### PR DESCRIPTION
The MIG, mlab3-dfw09, has been in production for upwards of 2 weeks. This commit removes it, and data analysis can now begin.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/43)
<!-- Reviewable:end -->
