### PR TITLE
Adds VMs in new GCP regions

### DIFF
--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -24,6 +24,7 @@ module "platform-cluster" {
         zone = "europe-west4-c"
       },
       mlab1-ber01 = {
+        # We cannot currently get any N2 quota in this region.
         machine_type = "e2-highcpu-4"
         zone         = "europe-west10-c"
       },
@@ -72,10 +73,12 @@ module "platform-cluster" {
         zone = "us-south1-a"
       },
       mlab1-dmm01 = {
+        # We cannot currently get any N2 quota in this region.
         machine_type = "e2-highcpu-4"
         zone         = "me-central2-c"
       },
       mlab1-doh01 = {
+        # We cannot currently get any N2 quota in this region.
         machine_type = "e2-highcpu-4"
         zone         = "me-central1-c"
       },

--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -23,6 +23,10 @@ module "platform-cluster" {
       mlab1-ams10 = {
         zone = "europe-west4-c"
       },
+      mlab1-ber01 = {
+        machine_type = "e2-highcpu-4"
+        zone         = "europe-west10-c"
+      },
       mlab1-bom03 = {
         zone = "asia-south1-c"
       },
@@ -66,6 +70,14 @@ module "platform-cluster" {
       },
       mlab3-dfw09 = {
         zone = "us-south1-a"
+      },
+      mlab1-dmm01 = {
+        machine_type = "e2-highcpu-4"
+        zone         = "me-central2-c"
+      },
+      mlab1-doh01 = {
+        machine_type = "e2-highcpu-4"
+        zone         = "me-central1-c"
       },
       mlab1-fra07 = {
         zone = "europe-west3-c"
@@ -363,10 +375,25 @@ module "platform-cluster" {
         name          = "kubernetes"
         region        = "europe-west9"
       },
+      "europe-west10" = {
+        ip_cidr_range = "10.38.0.0/16"
+        name          = "kubernetes"
+        region        = "europe-west10"
+      },
       "europe-west12" = {
         ip_cidr_range = "10.37.0.0/16"
         name          = "kubernetes"
         region        = "europe-west12"
+      },
+      "me-central1" = {
+        ip_cidr_range = "10.39.0.0/16"
+        name          = "kubernetes"
+        region        = "me-central1"
+      },
+      "me-central2" = {
+        ip_cidr_range = "10.40.0.0/16"
+        name          = "kubernetes"
+        region        = "me-central2"
       },
       "me-west1" = {
         ip_cidr_range = "10.35.0.0/16"

--- a/modules/platform-cluster/instances.tf
+++ b/modules/platform-cluster/instances.tf
@@ -43,7 +43,7 @@ resource "google_compute_instance" "api_instances" {
       network_tier = "PREMIUM"
     }
     network    = google_compute_network.platform_cluster.id
-    network_ip = google_compute_address.api_internal_addresses[each.key].id
+    network_ip = google_compute_address.api_internal_addresses[each.key].address
     stack_type = var.networking.attributes.stack_type
     subnetwork = google_compute_subnetwork.platform_cluster[var.api_instances.machine_attributes.region].id
   }


### PR DESCRIPTION
These regions are quite new to GCP:

europe-west10: Berlin, Germany
me-central1: Doha, Qatar
me-central2: Dammam, Saudi Arabia

The PR adds VMs in these regions. For some reason we are unable to get any quota for N2_CPUS in these regions, so these VMs are being deployed using E2 machine types, which should be okay.

This PR also makes a small change to the assigned value of `network_ip` for control plane instances. It assigns an actual address instead of a link or reference. This prevents TF from wanting update the instances in place on every run of "terraform apply".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/45)
<!-- Reviewable:end -->
