### PR TITLE
Removes VM from me-central2 + adds subnetwork to ipv6 addresses

### DIFF
--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -72,11 +72,6 @@ module "platform-cluster" {
       mlab3-dfw09 = {
         zone = "us-south1-a"
       },
-      mlab1-dmm01 = {
-        # We cannot currently get any N2 quota in this region.
-        machine_type = "e2-highcpu-4"
-        zone         = "me-central2-c"
-      },
       mlab1-doh01 = {
         # We cannot currently get any N2 quota in this region.
         machine_type = "e2-highcpu-4"
@@ -392,11 +387,6 @@ module "platform-cluster" {
         ip_cidr_range = "10.39.0.0/16"
         name          = "kubernetes"
         region        = "me-central1"
-      },
-      "me-central2" = {
-        ip_cidr_range = "10.40.0.0/16"
-        name          = "kubernetes"
-        region        = "me-central2"
       },
       "me-west1" = {
         ip_cidr_range = "10.35.0.0/16"

--- a/modules/platform-cluster/instances.tf
+++ b/modules/platform-cluster/instances.tf
@@ -171,7 +171,8 @@ resource "google_compute_address" "platform_addresses_v6" {
   name               = "${each.key}-${data.google_client_config.current.project}-measurement-lab-org-v6"
   # This regex is ugly, but I can't find a better way to extract the region from
   # the zone.
-  region = regex("^([a-z]+-[a-z0-9]+)-[a-z]$", each.value["zone"])[0]
+  region     = regex("^([a-z]+-[a-z0-9]+)-[a-z]$", each.value["zone"])[0]
+  subnetwork = google_compute_subnetwork.platform_cluster[regex("^([a-z]+-[a-z0-9]+)-[a-z]$", each.value["zone"])[0]].id
 }
 
 resource "google_compute_disk" "platform_boot_disks" {


### PR DESCRIPTION
When attempting to deploy resources in me-central2, The Google API says:

> Error 403: Permission denied by location policies

It would appear that this region is too new to support what we want to do without special intervention. For now, just remove it.

Also, without the subnetwork argument to `google_compute_address` for static IPv6 addresses, the Google API returns the error:

"Error 400: Required field 'resource.subnetwork' not specified"

However, this seems to conflict with the current documentation, which states this about the subnetwork field: 

> This field can only be used with INTERNAL type with GCE_ENDPOINT/DNS_RESOLVER purposes.

Since support for static IPv6 addresses is relatively recent, I suspect that the documentation is misaligned with the actual API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/46)
<!-- Reviewable:end -->
