### PR TITLE
Create static, internal, IPv4 addresses

### DIFF
--- a/modules/platform-cluster/instances.tf
+++ b/modules/platform-cluster/instances.tf
@@ -141,6 +141,7 @@ resource "google_compute_instance" "platform_instances" {
     }
 
     network    = google_compute_network.platform_cluster.id
+    network_ip = google_compute_address.platform_addresses_internal[each.key].address
     stack_type = var.networking.attributes.stack_type
     # Ugly: extract the region from the zone.
     subnetwork = google_compute_subnetwork.platform_cluster[regex("^([a-z]+-[a-z0-9]+)-[a-z]$", each.value["zone"])[0]].id
@@ -158,6 +159,15 @@ resource "google_compute_address" "platform_addresses" {
   for_each     = var.instances.vms
   address_type = "EXTERNAL"
   name         = "${each.key}-${data.google_client_config.current.project}-measurement-lab-org"
+  # This regex is ugly, but I can't find a better way to extract the region from
+  # the zone.
+  region = regex("^([a-z]+-[a-z0-9]+)-[a-z]$", each.value["zone"])[0]
+}
+
+resource "google_compute_address" "platform_addresses_internal" {
+  for_each     = var.instances.vms
+  address_type = "INTERNAL"
+  name         = "${each.key}-${data.google_client_config.current.project}-measurement-lab-org-internal"
   # This regex is ugly, but I can't find a better way to extract the region from
   # the zone.
   region = regex("^([a-z]+-[a-z0-9]+)-[a-z]$", each.value["zone"])[0]

--- a/modules/platform-cluster/instances.tf
+++ b/modules/platform-cluster/instances.tf
@@ -170,7 +170,8 @@ resource "google_compute_address" "platform_addresses_internal" {
   name         = "${each.key}-${data.google_client_config.current.project}-measurement-lab-org-internal"
   # This regex is ugly, but I can't find a better way to extract the region from
   # the zone.
-  region = regex("^([a-z]+-[a-z0-9]+)-[a-z]$", each.value["zone"])[0]
+  region     = regex("^([a-z]+-[a-z0-9]+)-[a-z]$", each.value["zone"])[0]
+  subnetwork = google_compute_subnetwork.platform_cluster[regex("^([a-z]+-[a-z0-9]+)-[a-z]$", each.value["zone"])[0]].id
 }
 
 resource "google_compute_address" "platform_addresses_v6" {


### PR DESCRIPTION
This PR creates static, internal, IPv4 address resources for platform VMs.

This PR should resolve a bug I discovered in which the `join-cluster` systemd unit writes the current internal address to a file for the `--node-ip` flag to the kubelet. If the VM has to be recreated for any reason (e.g., a new boot disk), it will get a different ephemeral IP address, causing a conflict between what we tell the kubelet the IP should be and what is actually configured on the machine. This should make sure that the internal IPv4 address never changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/47)
<!-- Reviewable:end -->
