### PR TITLE
Adds -no-color flag to terraform-apply

### DIFF
--- a/scripts/tf_apply.sh
+++ b/scripts/tf_apply.sh
@@ -80,7 +80,7 @@ function update_instances() {
       "
     fi
 
-    terraform apply -auto-approve -compact-warnings $targets
+    terraform apply -auto-approve -compact-warnings -no-color $targets
 
     # Wait until the machine is up and required services are running. For an API
     # server, this means that the /readyz endpoint returns 200. For platform
@@ -114,7 +114,7 @@ function main() {
   done
 
   # Now apply everything else.
-  terraform apply -auto-approve -compact-warnings
+  terraform apply -auto-approve -compact-warnings -no-color
 }
 
 main


### PR DESCRIPTION
This should prevent terraform from including a bunch of shell escape sequences to add color to the output, making the Cloud Builds logs a bit easier to read.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/48)
<!-- Reviewable:end -->
