### PR TITLE
Adds new virtual sites bom05 and dfw10

### DIFF
--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -37,6 +37,15 @@ module "platform-cluster" {
       mlab3-bom03 = {
         zone = "asia-south1-a"
       },
+      mlab1-bom05 = {
+        zone = "asia-south1-c"
+      },
+      mlab2-bom05 = {
+        zone = "asia-south1-b"
+      },
+      mlab3-bom05 = {
+        zone = "asia-south1-a"
+      },
       mlab1-bru06 = {
         zone = "europe-west1-c"
       },
@@ -70,6 +79,15 @@ module "platform-cluster" {
         zone = "us-south1-b"
       },
       mlab3-dfw09 = {
+        zone = "us-south1-a"
+      },
+      mlab1-dfw10 = {
+        zone = "us-south1-c"
+      },
+      mlab2-dfw10 = {
+        zone = "us-south1-b"
+      },
+      mlab3-dfw10 = {
         zone = "us-south1-a"
       },
       mlab1-doh01 = {


### PR DESCRIPTION
Each of these "sites" has 3 VMs. These are being added to provide additional capacity in these metros where we are struggling with higher than normal load which is causing switch discards at the physical sites.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/49)
<!-- Reviewable:end -->
