### PR TITLE
Adds new virtual site DFW11 with 3 VMs

### DIFF
--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -90,6 +90,15 @@ module "platform-cluster" {
       mlab3-dfw10 = {
         zone = "us-south1-a"
       },
+      mlab1-dfw11 = {
+        zone = "us-south1-c"
+      },
+      mlab2-dfw11 = {
+        zone = "us-south1-b"
+      },
+      mlab3-dfw11 = {
+        zone = "us-south1-a"
+      },
       mlab1-doh01 = {
         # We cannot currently get any N2 quota in this region.
         machine_type = "e2-highcpu-4"

--- a/mlab-sandbox/platform-cluster.tf
+++ b/mlab-sandbox/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-2023-10-12t19-01-53"
+      disk_image       = "platform-cluster-instance-2023-11-21t22-14-08"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -39,7 +39,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-2023-09-07t19-26-07"
+      disk_image        = "platform-cluster-api-instance-2023-11-21t22-14-08"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -73,7 +73,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-2023-09-07t19-26-07"
+    disk_image        = "platform-cluster-internal-instance-2023-11-21t22-14-08"
     disk_size_gb_boot = 100
     disk_size_gb_data = 200
     disk_type         = "pd-ssd"

--- a/mlab-sandbox/platform-cluster.tf
+++ b/mlab-sandbox/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-2023-09-07t19-26-07"
+      disk_image       = "platform-cluster-instance-2023-10-12t19-01-53"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"


### PR DESCRIPTION
Until we can get the periodic clients in DFW under control through filtering or outreach, we can keep trying to throw additional capacity in the metro to get discards at physical sites under control.

Also, updates disk images for sandbox instances.