### PR TITLE
Adds new mlab-autojoin project directory

### DIFF
--- a/cloudbuild-thirdparty.yaml
+++ b/cloudbuild-thirdparty.yaml
@@ -1,0 +1,23 @@
+# Timeout after 10h. Today, there are around 50 virtual machines in the
+# production cluster. On average it takes a single VM around 6.5m to be
+# deleted, recreated, and for ndt-server or the API to be available. If we
+# update the machines serially, this means a total build time of around 5.5
+# hours. Set the timeout to around double that just for room to grow.
+timeout: 36000s
+
+steps:
+- name: gcr.io/mlab-oti/gcloud-jsonnet-cbif:1.1
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |-
+    apt update
+    apt install --yes unzip
+    curl --remote-name https://releases.hashicorp.com/terraform/1.5.3/terraform_1.5.3_linux_amd64.zip
+    unzip terraform_1.5.3_linux_amd64.zip
+    mv terraform /usr/local/bin/
+    export PROJECT=$PROJECT_ID
+    bash scripts/tf_apply.sh $$PROJECT
+options:
+  logging: CLOUD_LOGGING_ONLY
+

--- a/mlab-autojoin/.terraform.lock.hcl
+++ b/mlab-autojoin/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.82.0"
+  constraints = "4.82.0"
+  hashes = [
+    "h1:+fK/35ZXJpT9ObamkkfPv04ckI7/vZz2HD7YaX+FmRE=",
+    "zh:057948f706d110fbc1ca87a6d1b84ce371001e1ddbb2a46a97e111a504afa563",
+    "zh:199fa8cc4c861514218f47ae46983788e82c92f919442052991a246e20618b15",
+    "zh:448d1bb13f7f3a2eff4de601049fe5fd877f7c875b65bec5f88ebfafdfcde3e7",
+    "zh:8f29d1e17954a33e6676c97cedd54d552102651ebd804de4eb52a553e05dbeb8",
+    "zh:993fa57d502a7e95e3b03b172a8bcfc3b72bc93c2c49eb0ded8bf98d37e0e7fc",
+    "zh:9fe645c4a42f826c849f209de4d71ef5f374ffa3c87e4a133e645da7224299b8",
+    "zh:ad9241394cfc0c7918ef0d3909f72daaaf0124ac108a45151fd09e051358023f",
+    "zh:c030521d5dfb07d5315f6af0e96c198889a23d13c32fd608036b704c6cadfa26",
+    "zh:c8512ee2087cccc09223f8e350509cb6fe53465c8a7b47d2a3c05c09262f16a1",
+    "zh:d03687da73d28d1bbace504b9a7e578522930762c964ede6fa4d5ebb8f7a607a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fe7e47546562b69a51d3706b12a9aa3b5fd478b18ba012980b8613dd12975d48",
+  ]
+}

--- a/mlab-autojoin/data-pipeline.tf
+++ b/mlab-autojoin/data-pipeline.tf
@@ -1,0 +1,40 @@
+module "data-pipeline" {
+  source = "../modules/data-pipeline"
+
+  providers = {
+    google = google.data-pipeline
+  }
+
+  node_pools = {
+    "processor" = {
+      initial_node_count = 1
+      machine_type       = "n2-standard-4"
+      max_node_count     = 2
+      max_surge          = 1
+      oauth_scopes = [
+        "https://www.googleapis.com/auth/bigquery",
+        "https://www.googleapis.com/auth/compute",
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/taskqueue"
+      ]
+    },
+    "prometheus" = {
+      initial_node_count = 1
+      machine_type       = "n2-standard-4"
+      max_node_count     = 2
+      max_surge          = 1
+      oauth_scopes = [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ]
+    }
+  }
+}

--- a/mlab-autojoin/main.tf
+++ b/mlab-autojoin/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  backend "gcs" {
+    # Terraform does not allow variable interpolation in backend blocks.
+    bucket = "terraform-support-mlab-autojoin"
+    prefix = "state"
+  }
+}
+
+provider "google" {
+  project = "mlab-autojoin"
+}
+
+provider "google" {
+  alias   = "data-pipeline"
+  project = "mlab-autojoin"
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}

--- a/mlab-autojoin/versions.tf
+++ b/mlab-autojoin/versions.tf
@@ -1,0 +1,1 @@
+../versions.tf


### PR DESCRIPTION
This new project root module imports the data-pipeline module, and deploys two new node pools: "processor" and "prometheus".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/53)
<!-- Reviewable:end -->
