### PR TITLE
Updates production VM boot disk images to latest tag

### DIFF
--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-v2-4-6"
+      disk_image       = "platform-cluster-instance-v2-4-8"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -243,7 +243,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-v2-4-6"
+      disk_image        = "platform-cluster-api-instance-v2-4-8"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -277,7 +277,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-v2-4-6"
+    disk_image        = "platform-cluster-internal-instance-v2-4-8"
     disk_size_gb_boot = 100
     disk_size_gb_data = 3500
     disk_type         = "pd-ssd"

--- a/scripts/assign_static_ipv6.sh
+++ b/scripts/assign_static_ipv6.sh
@@ -15,27 +15,27 @@ shift
 for m in $@; do
   machine="${m}-${PROJECT}-measurement-lab-org"
   zone=$(
-	gcloud compute instances list --filter "name:$machine" \
-	  --format "value(zone)" \
-	  --project $PROJECT
+    gcloud compute instances list --filter "name:$machine" \
+      --format "value(zone)" \
+      --project $PROJECT
   )
 
   # First make sure that the static address exists. The static address may not
   # exist if this VM was just created for the first time.
   existing_addr=$(
-	gcloud compute addresses list --filter "name:${machine}-v6" \
-	  --format "value(address)" \
-	  --project $PROJECT
+    gcloud compute addresses list --filter "name:${machine}-v6" \
+      --format "value(address)" \
+      --project $PROJECT
   )
 
   # If the static address doesn't exist, then create it.
   if [[ -z $existing_addr ]]; then
     gcloud compute addresses create "${machine}-v6" \
-	  --region ${zone%-*} \
-	  --subnet "kubernetes" \
-	  --ip-version "IPV6" \
-	  --endpoint-type "VM" \
-	  --project $PROJECT
+      --region ${zone%-*} \
+      --subnet "kubernetes" \
+      --ip-version "IPV6" \
+      --endpoint-type "VM" \
+      --project $PROJECT
   fi
 
   # This step effectively removes the ephemeral IPv6 address of the machine by
@@ -44,16 +44,17 @@ for m in $@; do
   # https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address#IP_assign
   gcloud compute instances network-interfaces update $machine \
     --network-interface=nic0 \
-	--stack-type=IPV4_ONLY \
-	--zone=$zone \
-	--project=$PROJECT
+    --stack-type=IPV4_ONLY \
+    --zone=$zone \
+    --project=$PROJECT
 
   gcloud compute instances network-interfaces update $machine \
     --network-interface=nic0 \
-	--ipv6-network-tier=PREMIUM \
-	--stack-type=IPV4_IPV6 \
-	--external-ipv6-address="${machine}-v6" \
+    --ipv6-network-tier=PREMIUM \
+    --stack-type=IPV4_IPV6 \
+    --external-ipv6-address="${machine}-v6" \
     --external-ipv6-prefix-length=96 \
-	--zone=$zone \
-	--project=$PROJECT
+    --zone=$zone \
+    --project=$PROJECT
 done
+

--- a/scripts/assign_static_ipv6.sh
+++ b/scripts/assign_static_ipv6.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# A small shell script which will remove an ephemeral IPv6 address from an
+# instance and reassign a static IPv6 to the same instance. This is a temporary
+# helper script which is run as a local-exec provisioner when instances are
+# [re]created by TF. GCP supports static regional IPv6 addresses, but the Google
+# Terraform provider does not yet support this.
+
+set -euxo pipefail
+
+PROJECT=${1? The first argument must be the GCP project}
+
+shift
+
+for m in $@; do
+  machine="${m}-${PROJECT}-measurement-lab-org"
+  zone=$(
+	gcloud compute instances list --filter "name:$machine" \
+	  --format "value(zone)" \
+	  --project $PROJECT
+  )
+
+  # First make sure that the static address exists. The static address may not
+  # exist if this VM was just created for the first time.
+  existing_addr=$(
+	gcloud compute addresses list --filter "name:${machine}-v6" \
+	  --format "value(address)" \
+	  --project $PROJECT
+  )
+
+  # If the static address doesn't exist, then create it.
+  if [[ -z $existing_addr ]]; then
+    gcloud compute addresses create "${machine}-v6" \
+	  --region ${zone%-*} \
+	  --subnet "kubernetes" \
+	  --ip-version "IPV6" \
+	  --endpoint-type "VM" \
+	  --project $PROJECT
+  fi
+
+  # This step effectively removes the ephemeral IPv6 address of the machine by
+  # specifying IPV4_ONLY. After which we add the existing static IPv6 address.
+  # This way of doing things comes directly from the Google documentation:
+  # https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address#IP_assign
+  gcloud compute instances network-interfaces update $machine \
+    --network-interface=nic0 \
+	--stack-type=IPV4_ONLY \
+	--zone=$zone \
+	--project=$PROJECT
+
+  gcloud compute instances network-interfaces update $machine \
+    --network-interface=nic0 \
+	--ipv6-network-tier=PREMIUM \
+	--stack-type=IPV4_IPV6 \
+	--external-ipv6-address="${machine}-v6" \
+    --external-ipv6-prefix-length=96 \
+	--zone=$zone \
+	--project=$PROJECT
+done


### PR DESCRIPTION
The latest tag includes images with k8s v1.26.12 components baked in, and should upgrade all production VMs to that version.

Additionally,  there is either some bug in our configs or in the Terraform Google provider in which when a VM gets recreated it does not get assigned the proper static IPv6 address, but instead an ephemeral IPv6 address. This PR restores [a script that was previously written](https://github.com/m-lab/terraform-support/pull/12/files) to address static IPv6 addresses at a point when GCP supported static regional IPv6 addresses for a VM, but the Google TF provider did not. The script is called by a `local-exec` provisioner and should address this bug until we can figure out the source. I _suspect_ this is a bug in the TF Google provider, and that this will no longer be necessary once we upgrade TF to the latest provider.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/55)
<!-- Reviewable:end -->
