### PR TITLE
Updates mlab-oti disk images to v2.4.9

### DIFF
--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-v2-4-8"
+      disk_image       = "platform-cluster-instance-v2-4-9"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -243,7 +243,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-v2-4-8"
+      disk_image        = "platform-cluster-api-instance-v2-4-9"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -277,7 +277,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-v2-4-8"
+    disk_image        = "platform-cluster-internal-instance-v2-4-9"
     disk_size_gb_boot = 100
     disk_size_gb_data = 3500
     disk_type         = "pd-ssd"


### PR DESCRIPTION
This should address this issue:

https://github.com/m-lab/ops-tracker/issues/1894#issuecomment-1883944954

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/57)
<!-- Reviewable:end -->
