### PR TITLE
Removes sites dfw10 and dfw11

### DIFF
--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -81,24 +81,6 @@ module "platform-cluster" {
       mlab3-dfw09 = {
         zone = "us-south1-a"
       },
-      mlab1-dfw10 = {
-        zone = "us-south1-c"
-      },
-      mlab2-dfw10 = {
-        zone = "us-south1-b"
-      },
-      mlab3-dfw10 = {
-        zone = "us-south1-a"
-      },
-      mlab1-dfw11 = {
-        zone = "us-south1-c"
-      },
-      mlab2-dfw11 = {
-        zone = "us-south1-b"
-      },
-      mlab3-dfw11 = {
-        zone = "us-south1-a"
-      },
       mlab1-doh01 = {
         # We cannot currently get any N2 quota in this region.
         machine_type = "e2-highcpu-4"


### PR DESCRIPTION
Now that periodic clients are under control in DFW, we can remove these additional virtual sites. [They have already been out of production](https://github.com/m-lab/ops-tracker/issues/1789#issuecomment-1854507360) for some weeks now, and also [removed from siteinfo](https://github.com/m-lab/siteinfo/pull/310). This change will just remove the VMs from GCP and the cluster.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/58)
<!-- Reviewable:end -->
