### PR TITLE
Add small improvement to tf_apply.sh script

### DIFF
--- a/mlab-sandbox/platform-cluster.tf
+++ b/mlab-sandbox/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-2024-01-23t22-50-49"
+      disk_image       = "platform-cluster-instance-2024-01-25t19-46-00"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -39,7 +39,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-2024-01-23t22-50-49"
+      disk_image        = "platform-cluster-api-instance-2024-01-25t19-46-00"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -73,7 +73,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-2024-01-23t22-50-49"
+    disk_image        = "platform-cluster-internal-instance-2024-01-25t19-46-00"
     disk_size_gb_boot = 100
     disk_size_gb_data = 200
     disk_type         = "pd-ssd"

--- a/mlab-sandbox/platform-cluster.tf
+++ b/mlab-sandbox/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-2024-01-16t23-19-45"
+      disk_image       = "platform-cluster-instance-2024-01-23t22-50-49"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -39,7 +39,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-2024-01-16t23-19-45"
+      disk_image        = "platform-cluster-api-instance-2024-01-23t22-50-49"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -73,7 +73,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-2024-01-16t23-19-45"
+    disk_image        = "platform-cluster-internal-instance-2024-01-23t22-50-49"
     disk_size_gb_boot = 100
     disk_size_gb_data = 200
     disk_type         = "pd-ssd"

--- a/mlab-staging/platform-cluster.tf
+++ b/mlab-staging/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-2024-01-17t16-56-17"
+      disk_image       = "platform-cluster-instance-2024-01-25t20-14-35"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -41,7 +41,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-2024-01-17t16-56-17"
+      disk_image        = "platform-cluster-api-instance-2024-01-25t20-14-35"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -75,7 +75,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-2024-01-17t16-56-17"
+    disk_image        = "platform-cluster-internal-instance-2024-01-25t20-14-35"
     disk_size_gb_boot = 100
     disk_size_gb_data = 1500
     disk_type         = "pd-ssd"

--- a/scripts/tf_apply.sh
+++ b/scripts/tf_apply.sh
@@ -123,12 +123,14 @@ function main() {
 
   # Now apply everything else.
   #
-  # TODO(kinkade: there is room for improvement here. If the calls to
+  # TODO(kinkade): there is room for improvement here. If the calls to
   # update_instances() above fail for some reason and changes to VMs do not get
   # applied one at a time, then the possibility exists that the following
   # command could unconditionally apply all changes at once. The virtual
   # machines should all recover, but it may cause unwanted downtime. Find a way
   # to not need this script, or to improve it to be a bit safer.
+  #
+  # https://github.com/m-lab/terraform-support/issues/61
   terraform apply -auto-approve -compact-warnings -no-color
 }
 


### PR DESCRIPTION
Currently, if the command substitution in the `for change in $()` loop in the `updates_instances()` function fails with an error, resulting in zero listed changes, even when changes actually exist, those changes will get applied by the blanket `terraform apply` in the `main()` function. What this means is that changes that require a VM to be recreated will not be rolled out serially, but instead will all rollout at once, like TF wants to do. While [recent changes in epoxy-images](https://github.com/m-lab/epoxy-images/pull/254) make this safe, it may still result in unwanted downtime of all VMs at once.

This PR introduces one small change which will cause the entire script to exit if there is some sort of error in any part of the command substitution of the `for change in $()` loop, which should help prevent all changes being applied at once by TF.

I also added a TODO comment for new functionality and error checking that might further prevent all changes being applied at once by TF.

All disk images in sandbox and staging are also updated, which contain the epoxy-images fixes I mentioned earlier which make applying all change at once safe, even if undesirable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/60)
<!-- Reviewable:end -->
