### PR TITLE
Updates disk images for mlab-oti to epoxy-images v2.4.10

### DIFF
--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-v2-4-9"
+      disk_image       = "platform-cluster-instance-v2-4-10"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -225,7 +225,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-v2-4-9"
+      disk_image        = "platform-cluster-api-instance-v2-4-10"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -259,7 +259,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-v2-4-9"
+    disk_image        = "platform-cluster-internal-instance-v2-4-10"
     disk_size_gb_boot = 100
     disk_size_gb_data = 3500
     disk_type         = "pd-ssd"


### PR DESCRIPTION
This PR updates the mlab-oti VM disk images to the latest version of epoxy-images. This latest version introduces some changes to the join-cluster.service systemd unit, making it `Restart=Always` so that it is more fault tolerant.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/62)
<!-- Reviewable:end -->
