### PR TITLE
Start the process of migrating most VMs to MIGs in production

### DIFF
--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -12,7 +12,7 @@ module "platform-cluster" {
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
-      mig_min_replicas = 3
+      mig_min_replicas = 1
       mig_max_replicas = 15
       network_tier     = "PREMIUM"
       tags             = ["ndt-cloud"]

--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -23,7 +23,7 @@ module "platform-cluster" {
         region = "asia-south2-c"
       },
       mlab1-hnd07 = {
-        region = "asia-northeast1-b"
+        region = "asia-northeast1-c"
       },
       mlab1-iad08 = {
         region = "us-east4-c"
@@ -132,13 +132,6 @@ module "platform-cluster" {
       },
       mlab1-hkg04 = {
         zone = "asia-east2-c"
-      },
-      mlab1-hnd06 = {
-        zone = "asia-northeast1-c"
-      },
-      mlab2-iad07 = {
-        network_tier = "STANDARD"
-        zone         = "us-east4-b"
       },
       mlab1-icn01 = {
         zone = "asia-northeast3-c"

--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -278,7 +278,17 @@ module "platform-cluster" {
       subnetwork_cidr = "10.0.0.0/8"
       vpc_name        = "mlab-platform-network"
     }
+    # This is not ideal, but when a new region is added, in order to find the
+    # next CIDR range not in use for the subnetwork, you can do something like
+    # the following:
+    #
+    # grep ip_cidr_range mlab-oti/platform-cluster.tf | sort --version-sort
     subnetworks = {
+      "africa-south1" = {
+        ip_cidr_range = "10.40.0.0/16"
+        name          = "kubernetes"
+        region        = "africa-south1"
+      },
       "asia-east1" = {
         ip_cidr_range = "10.9.0.0/16"
         name          = "kubernetes"

--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -18,7 +18,31 @@ module "platform-cluster" {
       tags             = ["ndt-cloud"]
       scopes           = ["cloud-platform"]
     }
-    migs = {}
+    migs = {
+      mlab1-del05 = {
+        region = "asia-south2-c"
+      },
+      mlab1-hnd07 = {
+        region = "asia-northeast1-b"
+      },
+      mlab1-iad08 = {
+        region = "us-east4-c"
+      },
+      mlab1-jnb02 = {
+        # This region is new and we don't currently have any N2 quota in it.
+        machine_type = "e2-highcpu-4"
+        region       = "africa-south1-c"
+      },
+      mlab1-lhr10 = {
+        region = "europe-west2-c"
+      },
+      mlab1-scl06 = {
+        region = "southamerica-west1-c"
+      },
+      mlab1-syd08 = {
+        region = "australia-southeast1-c"
+      }
+    }
     vms = {
       mlab1-ams10 = {
         zone = "europe-west4-c"
@@ -68,10 +92,6 @@ module "platform-cluster" {
       mlab1-cmh01 = {
         zone = "us-east5-c"
       },
-      mlab1-del03 = {
-        machine_type = "n2-highcpu-8"
-        zone         = "asia-south2-c"
-      },
       mlab1-dfw09 = {
         zone = "us-south1-c"
       },
@@ -116,15 +136,6 @@ module "platform-cluster" {
       mlab1-hnd06 = {
         zone = "asia-northeast1-c"
       },
-      mlab2-hnd06 = {
-        zone = "asia-northeast1-b"
-      },
-      mlab3-hnd06 = {
-        zone = "asia-northeast1-a"
-      },
-      mlab1-iad07 = {
-        zone = "us-east4-c"
-      },
       mlab2-iad07 = {
         network_tier = "STANDARD"
         zone         = "us-east4-b"
@@ -147,9 +158,6 @@ module "platform-cluster" {
       mlab1-lax07 = {
         zone = "us-west2-c"
       },
-      mlab1-lhr09 = {
-        zone = "europe-west2-c"
-      },
       mlab1-mad07 = {
         zone = "europe-southwest1-c"
       },
@@ -168,17 +176,11 @@ module "platform-cluster" {
       mlab1-pdx01 = {
         zone = "us-west1-c"
       },
-      mlab1-scl05 = {
-        zone = "southamerica-west1-c"
-      },
       mlab1-sin02 = {
         zone = "asia-southeast1-c"
       },
       mlab1-slc01 = {
         zone = "us-west3-c"
-      },
-      mlab1-syd07 = {
-        zone = "australia-southeast1-c"
       },
       mlab1-tlv01 = {
         zone = "me-west1-c"

--- a/modules/platform-cluster/instancegroups.tf
+++ b/modules/platform-cluster/instancegroups.tf
@@ -18,7 +18,7 @@ resource "google_compute_instance_template" "platform_cluster_mig_templates" {
     create_before_destroy = true
   }
 
-  machine_type = var.instances.attributes.machine_type
+  machine_type = lookup(each.value, "machine_type", var.instances.attributes.machine_type)
 
   metadata = {
     k8s_labels = join(",", [


### PR DESCRIPTION
This PR starts the process of migrating most standalone VMs to MIGs in production. To begin, we migrate one virtual site in each major region of the world to a MIG:

https://docs.google.com/document/d/1fX_ndIN2M0MiaguxONTTSXqR2C-JnsSs4PFReY45HuQ/edit#heading=h.umspiusj6y92

While I was starting to plan the migration, I noticed that GCP has a brand new region available in Johannesburg, South Africa. We have no N2_CPUs quote there, so I created a new MIG site (jnb02) using e2-highcpu-4 machines. In order to accomplish using E2 machines for jnb02 this PR also introduces allowing overrides for `machine_type` in the instance template for MIGs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/63)
<!-- Reviewable:end -->
