### PR TITLE
Replaces iad08 with iad09 in mlab-oti

### DIFF
--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -25,7 +25,7 @@ module "platform-cluster" {
       mlab1-hnd07 = {
         region = "asia-northeast1"
       },
-      mlab1-iad08 = {
+      mlab1-iad09 = {
         region = "us-east4"
       },
       mlab1-jnb02 = {


### PR DESCRIPTION
iad08 is already in use in mlab-staging, and has both an mlab3 and mlab4 machine. This was an early test to see how well it could work to have a non-mlab4 machine as part of staging. Rather than disturbing that staging deployment, this change just replaces iad08 in mlab-oti witih iad09.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/65)
<!-- Reviewable:end -->
