### PR TITLE
Adds new visualizations submodule

### DIFF
--- a/mlab-sandbox/main.tf
+++ b/mlab-sandbox/main.tf
@@ -23,3 +23,10 @@ provider "google" {
   region  = "us-central1"
   zone    = "us-central1-a"
 }
+
+provider "google" {
+  alias   = "visualizations"
+  project = "mlab-sandbox"
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}

--- a/mlab-sandbox/visualizations.tf
+++ b/mlab-sandbox/visualizations.tf
@@ -1,0 +1,7 @@
+module "visualizations" {
+  source = "../modules/visualizations"
+
+  providers = {
+    google = google.visualizations
+  }
+}

--- a/mlab-staging/main.tf
+++ b/mlab-staging/main.tf
@@ -23,3 +23,11 @@ provider "google" {
   region  = "us-central1"
   zone    = "us-central1-a"
 }
+
+provider "google" {
+  alias   = "visualizations"
+  project = "mlab-staging"
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}
+

--- a/mlab-staging/visualizations.tf
+++ b/mlab-staging/visualizations.tf
@@ -1,0 +1,7 @@
+module "visualizations" {
+  source = "../modules/visualizations"
+
+  providers = {
+    google = google.visualizations
+  }
+}

--- a/modules/visualizations/data.tf
+++ b/modules/visualizations/data.tf
@@ -1,0 +1,1 @@
+data "google_project" "current" {}

--- a/modules/visualizations/main.tf
+++ b/modules/visualizations/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+

--- a/modules/visualizations/serviceaccounts.tf
+++ b/modules/visualizations/serviceaccounts.tf
@@ -1,0 +1,65 @@
+#
+# Service Accounts
+#
+resource "google_service_account" "grafana_public" {
+  account_id   = "grafana-public"
+  description  = "Account for public Grafana instance. Member of discuss@"
+  display_name = "grafana-public"
+}
+
+#
+# Role Bindings
+#
+resource "google_project_iam_binding" "logging_logwriter" {
+  project = data.google_project.current.id
+  role    = "roles/logging.logWriter"
+
+  members = [
+    "serviceAccount:grafana-public@mlab-sandbox.iam.gserviceaccount.com"
+  ]
+}
+
+resource "google_project_iam_binding" "cloudtrace_agent" {
+  project = data.google_project.current.id
+  role    = "roles/cloudtrace.agent"
+
+  members = [
+    "serviceAccount:grafana-public@mlab-sandbox.iam.gserviceaccount.com"
+  ]
+}
+
+resource "google_project_iam_binding" "monitoring_metricwriter" {
+  project = data.google_project.current.id
+  role    = "roles/monitoring.metricWriter"
+
+  members = [
+    "serviceAccount:grafana-public@mlab-sandbox.iam.gserviceaccount.com"
+  ]
+}
+
+resource "google_project_iam_binding" "monitoring_metricsscopesviewer" {
+  project = data.google_project.current.id
+  role    = "roles/monitoring.metricsScopesViewer"
+
+  members = [
+    "serviceAccount:grafana-public@mlab-sandbox.iam.gserviceaccount.com"
+  ]
+}
+
+resource "google_project_iam_binding" "storage_objectviewer" {
+  project = data.google_project.current.id
+  role    = "roles/storage.objectViewer"
+
+  members = [
+    "serviceAccount:grafana-public@mlab-sandbox.iam.gserviceaccount.com"
+  ]
+}
+
+resource "google_project_iam_binding" "artifactregistry_reader" {
+  project = data.google_project.current.id
+  role    = "roles/artifactregistry.reader"
+
+  members = [
+    "serviceAccount:grafana-public@mlab-sandbox.iam.gserviceaccount.com"
+  ]
+}

--- a/modules/visualizations/serviceaccounts.tf
+++ b/modules/visualizations/serviceaccounts.tf
@@ -15,7 +15,7 @@ resource "google_project_iam_binding" "logging_logwriter" {
   role    = "roles/logging.logWriter"
 
   members = [
-    "serviceAccount:grafana-public@mlab-sandbox.iam.gserviceaccount.com"
+    "serviceAccount:grafana-public@${data.google_project.current.project_id}.iam.gserviceaccount.com"
   ]
 }
 
@@ -24,7 +24,7 @@ resource "google_project_iam_binding" "cloudtrace_agent" {
   role    = "roles/cloudtrace.agent"
 
   members = [
-    "serviceAccount:grafana-public@mlab-sandbox.iam.gserviceaccount.com"
+    "serviceAccount:grafana-public@${data.google_project.current.project_id}.iam.gserviceaccount.com"
   ]
 }
 
@@ -33,7 +33,7 @@ resource "google_project_iam_binding" "monitoring_metricwriter" {
   role    = "roles/monitoring.metricWriter"
 
   members = [
-    "serviceAccount:grafana-public@mlab-sandbox.iam.gserviceaccount.com"
+    "serviceAccount:grafana-public@${data.google_project.current.project_id}.iam.gserviceaccount.com"
   ]
 }
 
@@ -42,7 +42,7 @@ resource "google_project_iam_binding" "monitoring_metricsscopesviewer" {
   role    = "roles/monitoring.metricsScopesViewer"
 
   members = [
-    "serviceAccount:grafana-public@mlab-sandbox.iam.gserviceaccount.com"
+    "serviceAccount:grafana-public@${data.google_project.current.project_id}.iam.gserviceaccount.com"
   ]
 }
 
@@ -51,7 +51,7 @@ resource "google_project_iam_binding" "storage_objectviewer" {
   role    = "roles/storage.objectViewer"
 
   members = [
-    "serviceAccount:grafana-public@mlab-sandbox.iam.gserviceaccount.com"
+    "serviceAccount:grafana-public@${data.google_project.current.project_id}.iam.gserviceaccount.com"
   ]
 }
 
@@ -60,6 +60,6 @@ resource "google_project_iam_binding" "artifactregistry_reader" {
   role    = "roles/artifactregistry.reader"
 
   members = [
-    "serviceAccount:grafana-public@mlab-sandbox.iam.gserviceaccount.com"
+    "serviceAccount:grafana-public@${data.google_project.current.project_id}.iam.gserviceaccount.com"
   ]
 }


### PR DESCRIPTION
The immediate use of this submodule will be to configure the proper service accounts for the grafana-public AppEngine instance. The build of this PR is adding the appropriate IAM role bindings to the new grafana-public@ service account.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/66)
<!-- Reviewable:end -->
