### PR TITLE
Updates VM disk images in sandbox and staging 

### DIFF
--- a/mlab-sandbox/platform-cluster.tf
+++ b/mlab-sandbox/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-2024-01-25t19-46-00"
+      disk_image       = "platform-cluster-instance-2024-02-13t21-13-10"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -39,7 +39,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-2024-01-25t19-46-00"
+      disk_image        = "platform-cluster-api-instance-2024-02-13t21-13-10"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -73,7 +73,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-2024-01-25t19-46-00"
+    disk_image        = "platform-cluster-internal-instance-2024-02-13t21-13-10"
     disk_size_gb_boot = 100
     disk_size_gb_data = 200
     disk_type         = "pd-ssd"

--- a/mlab-staging/platform-cluster.tf
+++ b/mlab-staging/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-2024-01-25t20-14-35"
+      disk_image       = "platform-cluster-instance-2024-02-13t23-11-03"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -41,7 +41,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-2024-01-25t20-14-35"
+      disk_image        = "platform-cluster-api-instance-2024-02-13t23-11-03"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -75,7 +75,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-2024-01-25t20-14-35"
+    disk_image        = "platform-cluster-internal-instance-2024-02-13t23-11-03"
     disk_size_gb_boot = 100
     disk_size_gb_data = 1500
     disk_type         = "pd-ssd"


### PR DESCRIPTION
The impetus behind the change is writing different metadata, depending on whether the VM is standalone or part of a MIG:

https://github.com/m-lab/epoxy-images/pull/255

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/67)
<!-- Reviewable:end -->
