### PR TITLE
Updates VM disk images in a projects

### DIFF
--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-v2-4-10"
+      disk_image       = "platform-cluster-instance-v2-4-11"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -220,7 +220,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-v2-4-10"
+      disk_image        = "platform-cluster-api-instance-v2-4-11"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -254,7 +254,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-v2-4-10"
+    disk_image        = "platform-cluster-internal-instance-v2-4-11"
     disk_size_gb_boot = 100
     disk_size_gb_data = 3500
     disk_type         = "pd-ssd"

--- a/mlab-sandbox/platform-cluster.tf
+++ b/mlab-sandbox/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-2024-02-13t21-13-10"
+      disk_image       = "platform-cluster-instance-2024-02-28t18-42-50"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -39,7 +39,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-2024-02-13t21-13-10"
+      disk_image        = "platform-cluster-api-instance-2024-02-28t18-42-50"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -73,7 +73,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-2024-02-13t21-13-10"
+    disk_image        = "platform-cluster-internal-instance-2024-02-28t18-42-50"
     disk_size_gb_boot = 100
     disk_size_gb_data = 200
     disk_type         = "pd-ssd"

--- a/mlab-staging/platform-cluster.tf
+++ b/mlab-staging/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-2024-02-13t23-11-03"
+      disk_image       = "platform-cluster-instance-2024-02-28t20-34-27"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -41,7 +41,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-2024-02-13t23-11-03"
+      disk_image        = "platform-cluster-api-instance-2024-02-28t20-34-27"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -75,7 +75,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-2024-02-13t23-11-03"
+    disk_image        = "platform-cluster-internal-instance-2024-02-28t20-34-27"
     disk_size_gb_boot = 100
     disk_size_gb_data = 1500
     disk_type         = "pd-ssd"


### PR DESCRIPTION
This new images contain the update where the write_metadata.sh script will write MIG load balancer IPs to the /var/local/metadata/external_ip[v6] files instead of the ones associated with the MIG instance, which aren't the
addresses that clients will actually be interacting with.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/68)
<!-- Reviewable:end -->
