### PR TITLE
Add new project root module for measurement-lab

### DIFF
--- a/measurement-lab/.terraform.lock.hcl
+++ b/measurement-lab/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.12.0"
+  constraints = "5.12.0"
+  hashes = [
+    "h1:yhJP34vbX7JeSJ18SdYPRn4SvZnRiQ0UBYj6nO5i3io=",
+    "zh:1b5ee0b443de62e300a1efb4002d8838fcd268de51aed62b0b1ab0c0b0015f81",
+    "zh:52db2fbcad001915a5f8bc5c3e81b9f9431c38b4e3f44ef5b0be844f0c9daca4",
+    "zh:5ea6dcfe87889a135a0b5557a377a40c1bef48ce82add355aba16c20de1f3009",
+    "zh:642c2946ecff3eabbe6fea7a1eff1ad184e9c26b2455413273af8fc23eee13ed",
+    "zh:6c539d2f13d76481ee8dff386182b87650b7f9fd19da13df8e26f370fe7237e3",
+    "zh:719f555345c51f87e73b72c1db315282e788a893e697c423231ebd104ab55d0d",
+    "zh:a2bdbc77cce6a785ef35e13163d3b14c1aa1cac88d2afebbf6124c49afdbca6f",
+    "zh:cf51754d9afa22141160af5da3d13d0eb286b82b10c93058fe5557871e62a534",
+    "zh:d7f54e3eddac6819849e77e3901ed0b968cb65ed0f0158fa7eaea9ca56a62cb4",
+    "zh:e8c8740674d141589c9dbf62f26fe67aecf4090ff1de5f12a4489e9b29a7253b",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f6d4c7e2fd0f8bd55c58e11024ab359e5b88c48ebf7ad40848470344a0242fa8",
+  ]
+}

--- a/measurement-lab/main.tf
+++ b/measurement-lab/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  backend "gcs" {
+    # Terraform does not allow variable interpolation in backend blocks.
+    bucket = "terraform-support-measurement-lab"
+    prefix = "state"
+  }
+}
+
+provider "google" {
+  project = "measurement-lab"
+}
+
+provider "google" {
+  alias   = "platform-cluster"
+  project = "measurement-lab"
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}
+
+provider "google" {
+  alias   = "data-pipeline"
+  project = "measurement-lab"
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}
+
+provider "google" {
+  alias   = "visualizations"
+  project = "measurement-lab"
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}

--- a/measurement-lab/versions.tf
+++ b/measurement-lab/versions.tf
@@ -1,0 +1,1 @@
+../versions.tf

--- a/measurement-lab/visualizations.tf
+++ b/measurement-lab/visualizations.tf
@@ -1,0 +1,7 @@
+module "visualizations" {
+  source = "../modules/visualizations"
+
+  providers = {
+    google = google.visualizations
+  }
+}

--- a/mlab-autojoin/main.tf
+++ b/mlab-autojoin/main.tf
@@ -16,3 +16,17 @@ provider "google" {
   region  = "us-central1"
   zone    = "us-central1-a"
 }
+
+provider "google" {
+  alias   = "platform-cluster"
+  project = "mlab-autojoin"
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}
+
+provider "google" {
+  alias   = "visualizations"
+  project = "mlab-autojoin"
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}

--- a/mlab-oti/main.tf
+++ b/mlab-oti/main.tf
@@ -23,3 +23,10 @@ provider "google" {
   region  = "us-central1"
   zone    = "us-central1-a"
 }
+
+provider "google" {
+  alias   = "visualizations"
+  project = "mlab-oti"
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,8 @@ terraform {
       version = "5.12.0"
       configuration_aliases = [
         google.data-pipeline,
-        google.platform-cluster
+        google.platform-cluster,
+        google.visualizations
       ]
     }
   }


### PR DESCRIPTION
We plan to host the public Grafana instance in the measurement-lab GCP project. This PR adds a new project root module for this project, and populates it with the "visualizations" module.

Additionally, I discovered that the google.visualizations provider alias was not listed in the `configuration_aliases` list in versions.tf. Things still _seemed_ to work as intended in mlab-sandbox and mlab-staging, despite [the documentation stating](https://developer.hashicorp.com/terraform/language/providers/configuration#alias-multiple-provider-configurations) that all aliases should be listed there. In any case, this PR adds that alias to versions.tf, which is shared by all project root modules (it's a symlink). But then, if it is listed there and you don't define that alias in the root module, TF will emit an error, so this PR adds that definition to main.tf of mlab-oti, too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/69)
<!-- Reviewable:end -->
