### PR TITLE
Adds a new "common" module

### DIFF
--- a/mlab-oti/common.tf
+++ b/mlab-oti/common.tf
@@ -1,0 +1,8 @@
+module "common" {
+  source = "../modules/common"
+
+  providers = {
+    google = google.common
+  }
+}
+

--- a/mlab-oti/main.tf
+++ b/mlab-oti/main.tf
@@ -30,3 +30,11 @@ provider "google" {
   region  = "us-central1"
   zone    = "us-central1-a"
 }
+
+provider "google" {
+  alias   = "common"
+  project = "mlab-oti"
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}
+

--- a/mlab-sandbox/common.tf
+++ b/mlab-sandbox/common.tf
@@ -1,0 +1,8 @@
+module "common" {
+  source = "../modules/common"
+
+  providers = {
+    google = google.common
+  }
+}
+

--- a/mlab-sandbox/main.tf
+++ b/mlab-sandbox/main.tf
@@ -30,3 +30,10 @@ provider "google" {
   region  = "us-central1"
   zone    = "us-central1-a"
 }
+
+provider "google" {
+  alias   = "common"
+  project = "mlab-sandbox"
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}

--- a/mlab-staging/common.tf
+++ b/mlab-staging/common.tf
@@ -1,0 +1,8 @@
+module "common" {
+  source = "../modules/common"
+
+  providers = {
+    google = google.common
+  }
+}
+

--- a/mlab-staging/main.tf
+++ b/mlab-staging/main.tf
@@ -31,3 +31,10 @@ provider "google" {
   zone    = "us-central1-a"
 }
 
+provider "google" {
+  alias   = "common"
+  project = "mlab-staging"
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}
+

--- a/modules/common/artifactregistry.tf
+++ b/modules/common/artifactregistry.tf
@@ -1,0 +1,13 @@
+resource "google_artifact_registry_repository" "build_images" {
+  location      = "us-central1"
+  repository_id = "build-images"
+  description   = "Cloud Build container images"
+  format        = "DOCKER"
+}
+
+resource "google_artifact_registry_repository_iam_member" "member" {
+  location   = google_artifact_registry_repository.build_images.location
+  repository = google_artifact_registry_repository.build_images.name
+  role       = "roles/artifactregistry.reader"
+  member     = "allUsers"
+}

--- a/modules/common/main.tf
+++ b/modules/common/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+


### PR DESCRIPTION
We currently have submodules specific to certain related infrastructure in GCP (e.g., platform-cluster, data-pipeline). There are quite a lot of resources in GCP that do not fall neatly into one piece of infrastructure, or that may be used by multiple things. This "common" submodule is a place to defined such resources.

As a start, this modules adds a new "build-images" Artifact Registry repository and makes it publicly readable.