### PR TITLE
Adds foundations provider def to two additional projects

### DIFF
--- a/measurement-lab/main.tf
+++ b/measurement-lab/main.tf
@@ -30,3 +30,11 @@ provider "google" {
   region  = "us-central1"
   zone    = "us-central1-a"
 }
+
+provider "google" {
+  alias   = "foundations"
+  project = "measurement-lab"
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}
+

--- a/mlab-autojoin/main.tf
+++ b/mlab-autojoin/main.tf
@@ -30,3 +30,11 @@ provider "google" {
   region  = "us-central1"
   zone    = "us-central1-a"
 }
+
+provider "google" {
+  alias   = "foundations"
+  project = "mlab-autojoin"
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}
+


### PR DESCRIPTION
Whether a project root module uses a particular submodule or not, it still must defined the provider alias for all modules, since all project root modules share a common versions.tf file, which defines which provider aliases should exist. When I created the foundations module yesterday, I forgot to add the provider alias to the mlab-autojoin and measurement-lab projects.

There is probably a better way to do this, but I just haven't figured it out yet. We aren't even using the provider alias features yet, for the most part, but its nice to have them there in case we need them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/72)
<!-- Reviewable:end -->
