### PR TITLE
Substitutes _only_ the build image project in Cloud Build config

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,19 +5,16 @@
 # hours. Set the timeout to around double that just for room to grow.
 timeout: 36000s
 
-# $_CONTAINER_IMAGE is going to be some form of:
-#
-#     gcr.io/<project>/gcloud-jsonnet-cbif
-#
-# We have this in a Cloud Build user-defined substitution variable because
-# this build gets run in more projects that just the standard
+# We have $_IMAGE_PROJECT in a Cloud Build user-defined substitution variable
+# because this build gets run in more projects that just the standard
 # sandbox->staging->prod, but those projects are the only ones where the
-# container image is built and pushed to Artifact Registry. The other projects
-# are "mlab-autojoin" and "measurement-lab", both of which are production
-# projects, so in those we want to use the "mlab-oti" (prod) image. The value of
-# this variable is defined in the build trigger of each project.
+# container images are built and pushed to Artifact Registry. The other
+# production projects where this build will happen are "mlab-autojoin" and
+# "measurement-lab", which are production projects, so we want to use the
+# "mlab-oti" (production) image. The value of this variable is defined in the
+# build trigger of each project.
 steps:
-- name: ${_CONTAINER_IMAGE}:1.1
+- name: us-central1-docker.pkg.dev/${_IMAGE_PROJECT}/build-images/gcloud-jsonnet-cbif
   entrypoint: /bin/bash
   args:
   - -c

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,7 +14,7 @@ timeout: 36000s
 # "mlab-oti" (production) image. The value of this variable is defined in the
 # build trigger of each project.
 steps:
-- name: us-central1-docker.pkg.dev/${_IMAGE_PROJECT}/build-images/gcloud-jsonnet-cbif
+- name: us-central1-docker.pkg.dev/${_IMAGE_PROJECT}/build-images/gcloud-jsonnet-cbif:1.1
   entrypoint: /bin/bash
   args:
   - -c


### PR DESCRIPTION
In order to make it more transparent which build image is getting run, this change substitutes _only_ the project of the build image rather than the entire image name.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/74)
<!-- Reviewable:end -->
