### PR TITLE
Fix a typo in "mlab_staging", which should be a dash

### DIFF
--- a/scripts/tf_apply.sh
+++ b/scripts/tf_apply.sh
@@ -120,7 +120,7 @@ function main() {
   # We only want interate over instances in the M-Lab Platform clusters, which
   # only exist on our main three sandbox->staging->prod GCP projects.
   case "$PROJECT" in
-    mlab-sandbox|mlab_staging|mlab-oti)
+    mlab-sandbox|mlab-staging|mlab-oti)
       for target in api platform; do
         update_instances $target
       done


### PR DESCRIPTION
This was a typo from a previous PR. The result was some amount of breakage in staging when I merged the previous PR.