### PR TITLE
Replaces MIG lax08 with lax10

### DIFF
--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -59,7 +59,7 @@ module "platform-cluster" {
         machine_type = "e2-highcpu-4"
         region       = "africa-south1"
       },
-      mlab1-lax08 = {
+      mlab1-lax10 = {
         region = "us-west2"
       },
       mlab1-lhr10 = {


### PR DESCRIPTION
I failed to notice that site lax08 already existed in staging. lax09 is a retired virtual site, so lax10 is the next lax site to use.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/78)
<!-- Reviewable:end -->
