### PR TITLE
Upgrade production VMs' disk_image to k8s v1.27.12

### DIFF
--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-v2-4-12"
+      disk_image       = "platform-cluster-instance-v2-4-15"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -258,7 +258,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-v2-4-12"
+      disk_image        = "platform-cluster-api-instance-v2-4-15"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -292,7 +292,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-v2-4-12"
+    disk_image        = "platform-cluster-internal-instance-v2-4-15"
     disk_size_gb_boot = 100
     disk_size_gb_data = 3500
     disk_type         = "pd-ssd"


### PR DESCRIPTION
Also see #79.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/80)
<!-- Reviewable:end -->
