### PR TITLE
Remove round 2 MIG migration standalone VMs

### DIFF
--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-v2-4-15"
+      disk_image       = "platform-cluster-instance-v2-4-18"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -164,7 +164,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-v2-4-15"
+      disk_image        = "platform-cluster-api-instance-v2-4-18"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -198,7 +198,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-v2-4-15"
+    disk_image        = "platform-cluster-internal-instance-v2-4-18"
     disk_size_gb_boot = 100
     disk_size_gb_data = 3500
     disk_type         = "pd-ssd"

--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -90,15 +90,6 @@ module "platform-cluster" {
         machine_type = "e2-highcpu-4"
         zone         = "europe-west10-c"
       },
-      mlab1-bom03 = {
-        zone = "asia-south1-c"
-      },
-      mlab2-bom03 = {
-        zone = "asia-south1-b"
-      },
-      mlab3-bom03 = {
-        zone = "asia-south1-a"
-      },
       mlab1-bom05 = {
         zone = "asia-south1-c"
       },
@@ -111,38 +102,8 @@ module "platform-cluster" {
       mlab1-bru06 = {
         zone = "europe-west1-c"
       },
-      mlab1-cgk01 = {
-        zone = "asia-southeast2-c"
-      },
-      mlab2-cgk01 = {
-        zone = "asia-southeast2-b"
-      },
-      mlab3-cgk01 = {
-        zone = "asia-southeast2-a"
-      },
-      mlab1-chs01 = {
-        zone = "us-east1-c"
-      },
-      mlab2-chs01 = {
-        network_tier = "STANDARD"
-        zone         = "us-east1-b"
-      },
       mlab1-cmh01 = {
         zone = "us-east5-c"
-      },
-      mlab1-dfw09 = {
-        zone = "us-south1-c"
-      },
-      mlab2-dfw09 = {
-        zone = "us-south1-b"
-      },
-      mlab3-dfw09 = {
-        zone = "us-south1-a"
-      },
-      mlab1-doh01 = {
-        # We cannot currently get any N2 quota in this region.
-        machine_type = "e2-highcpu-4"
-        zone         = "me-central1-c"
       },
       mlab1-fra07 = {
         zone = "europe-west3-c"
@@ -150,44 +111,14 @@ module "platform-cluster" {
       mlab2-fra07 = {
         zone = "europe-west3-b"
       },
-      mlab1-gru05 = {
-        zone = "southamerica-east1-c"
-      },
-      mlab2-gru05 = {
-        zone = "southamerica-east1-b"
-      },
-      mlab3-gru05 = {
-        zone = "southamerica-east1-a"
-      },
-      mlab1-hel01 = {
-        zone = "europe-north1-c"
-      },
-      mlab2-hel01 = {
-        zone = "europe-north1-b"
-      },
-      mlab3-hel01 = {
-        zone = "europe-north1-a"
-      },
       mlab1-hkg04 = {
         zone = "asia-east2-c"
-      },
-      mlab1-icn01 = {
-        zone = "asia-northeast3-c"
-      },
-      mlab2-icn01 = {
-        zone = "asia-northeast3-b"
-      },
-      mlab3-icn01 = {
-        zone = "asia-northeast3-a"
       },
       mlab1-kix01 = {
         zone = "asia-northeast2-c"
       },
       mlab1-las01 = {
         zone = "us-west4-c"
-      },
-      mlab1-lax07 = {
-        zone = "us-west2-c"
       },
       mlab1-mad07 = {
         zone = "europe-southwest1-c"
@@ -225,33 +156,8 @@ module "platform-cluster" {
       mlab1-trn03 = {
         zone = "europe-west12-c"
       },
-      mlab1-waw01 = {
-        zone = "europe-central2-c"
-      },
-      mlab2-waw01 = {
-        zone = "europe-central2-b"
-      },
-      mlab3-waw01 = {
-        zone = "europe-central2-a"
-      },
-      mlab1-yul07 = {
-        zone = "northamerica-northeast1-c"
-      },
-      mlab2-yul07 = {
-        network_tier = "STANDARD"
-        zone         = "northamerica-northeast1-b"
-      },
       mlab1-yyz07 = {
         zone = "northamerica-northeast2-c"
-      },
-      mlab1-zrh01 = {
-        zone = "europe-west6-c"
-      },
-      mlab2-zrh01 = {
-        zone = "europe-west6-b"
-      },
-      mlab3-zrh01 = {
-        zone = "europe-west6-a"
       }
     }
   }

--- a/mlab-sandbox/platform-cluster.tf
+++ b/mlab-sandbox/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-2024-04-09t17-48-31"
+      disk_image       = "platform-cluster-instance-2024-07-11t18-55-44"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -39,7 +39,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-2024-04-09t17-48-31"
+      disk_image        = "platform-cluster-api-instance-2024-07-11t18-55-44"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -73,7 +73,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-2024-04-09t17-48-31"
+    disk_image        = "platform-cluster-internal-instance-2024-07-11t18-55-44"
     disk_size_gb_boot = 100
     disk_size_gb_data = 200
     disk_type         = "pd-ssd"

--- a/mlab-sandbox/platform-cluster.tf
+++ b/mlab-sandbox/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-2024-07-11t18-55-44"
+      disk_image       = "platform-cluster-instance-2024-07-15t17-24-36"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -39,7 +39,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-2024-07-11t18-55-44"
+      disk_image        = "platform-cluster-api-instance-2024-07-15t17-24-36"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -73,7 +73,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-2024-07-11t18-55-44"
+    disk_image        = "platform-cluster-internal-instance-2024-07-15t17-24-36"
     disk_size_gb_boot = 100
     disk_size_gb_data = 200
     disk_type         = "pd-ssd"

--- a/mlab-staging/platform-cluster.tf
+++ b/mlab-staging/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-2024-04-09t18-50-56"
+      disk_image       = "platform-cluster-instance-2024-07-11t20-59-52"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -41,7 +41,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-2024-04-09t18-50-56"
+      disk_image        = "platform-cluster-api-instance-2024-07-11t20-59-52"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -75,7 +75,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-2024-04-09t18-50-56"
+    disk_image        = "platform-cluster-internal-instance-2024-07-11t20-59-52"
     disk_size_gb_boot = 100
     disk_size_gb_data = 1500
     disk_type         = "pd-ssd"

--- a/mlab-staging/platform-cluster.tf
+++ b/mlab-staging/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-2024-07-11t20-59-52"
+      disk_image       = "platform-cluster-instance-2024-07-15t20-45-53"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -41,7 +41,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-2024-07-11t20-59-52"
+      disk_image        = "platform-cluster-api-instance-2024-07-15t20-45-53"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -75,7 +75,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-2024-07-11t20-59-52"
+    disk_image        = "platform-cluster-internal-instance-2024-07-15t20-45-53"
     disk_size_gb_boot = 100
     disk_size_gb_data = 1500
     disk_type         = "pd-ssd"


### PR DESCRIPTION
Round 2 of MIG migrations is complete, and we are now safe to remove the standalone VMs which the MIGs replaced.

Additionally, while nothing has changed in the virtual images, several epoxy-images builds have updated the latest image versions available. To keep things consistent and up-to-date, this PR also updates the disk images for VMs in all project, which should be a no-op in terms of functionality.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/81)
<!-- Reviewable:end -->
