### PR TITLE
Reduces max instances for MIGs in each project

### DIFF
--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -13,7 +13,7 @@ module "platform-cluster" {
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
       mig_min_replicas = 1
-      mig_max_replicas = 15
+      mig_max_replicas = 5
       network_tier     = "PREMIUM"
       tags             = ["ndt-cloud"]
       scopes           = ["cloud-platform"]

--- a/mlab-sandbox/platform-cluster.tf
+++ b/mlab-sandbox/platform-cluster.tf
@@ -13,7 +13,7 @@ module "platform-cluster" {
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
       mig_min_replicas = 1
-      mig_max_replicas = 5
+      mig_max_replicas = 2
       network_tier     = "PREMIUM"
       tags             = ["ndt-cloud"]
       scopes           = ["cloud-platform"]

--- a/mlab-staging/platform-cluster.tf
+++ b/mlab-staging/platform-cluster.tf
@@ -13,13 +13,13 @@ module "platform-cluster" {
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
       mig_min_replicas = 1
-      mig_max_replicas = 10
+      mig_max_replicas = 3
       network_tier     = "PREMIUM"
       tags             = ["ndt-cloud"]
       scopes           = ["cloud-platform"]
     },
     migs = {
-      mlab4-dfw09 = {
+      mlab4-dfw13 = {
         region = "us-south1"
       }
     },


### PR DESCRIPTION
Previously the max instances for MIGs were 5, 10, 15 for mlab-sandbox, mlab-staging, mlab-oti, respectively. This PR reduces those to 2, 3, 5, also respectively. It is good for MIGs to scale out and in, but we need to set a more reasonable upper bound in order to prevent large traffic spikes from causing excessive GCP egress network charges.

Additionally, add MIG dfw13 to staging. dfw09 was retired a week ago, but I had failed to remove it from the TF configs. However, we should have a least one MIG in each project for testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/83)
<!-- Reviewable:end -->
