### PR TITLE
Removes staging standalone VM mlab4-oma01

### DIFF
--- a/mlab-staging/platform-cluster.tf
+++ b/mlab-staging/platform-cluster.tf
@@ -32,9 +32,6 @@ module "platform-cluster" {
       },
       mlab4-lax08 = {
         zone = "us-west2-c"
-      },
-      mlab4-oma01 = {
-        zone = "us-central1-c"
       }
     }
   }


### PR DESCRIPTION
The production VM mlab1-oma01 was removed as part of the 3rd and final round of MIG migrations. This was a somewhat odd site which had both a production and staging node configured. When I retired the production site I failed to retire the staging machine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/91)
<!-- Reviewable:end -->
