### PR TITLE
Add autonode VM to the mlab-autojoin project, too

### DIFF
--- a/mlab-autojoin/autojoin.tf
+++ b/mlab-autojoin/autojoin.tf
@@ -1,0 +1,7 @@
+module "autojoin" {
+  source = "../modules/autojoin"
+
+  providers = {
+    google = google.autojoin
+  }
+}

--- a/mlab-autojoin/main.tf
+++ b/mlab-autojoin/main.tf
@@ -38,3 +38,9 @@ provider "google" {
   zone    = "us-central1-a"
 }
 
+provider "google" {
+  alias   = "autojoin"
+  project = "mlab-autojoin"
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}


### PR DESCRIPTION
This sets up the same VM we run in sandbox/staging in mlab-autojoin.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/92)
<!-- Reviewable:end -->
