### PR TITLE
Enable dual-stack IPv4/v6 on autonode VM

### DIFF
--- a/modules/autojoin/firewall.tf
+++ b/modules/autojoin/firewall.tf
@@ -37,3 +37,17 @@ resource "google_compute_firewall" "ndt_access" {
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["ndt-server"]
 }
+
+# Allow external access to any port for IPv6 traffic platform VMs.
+resource "google_compute_firewall" "ndt_access_ipv6" {
+  allow {
+    ports    = ["80", "443"]
+    protocol = "tcp"
+  }
+
+  description   = "Allow IPv6 access to NDT servers"
+  name          = "ndt-access-ipv6"
+  network       = google_compute_network.autojoin.name
+  source_ranges = ["::/0"]
+  target_tags   = ["ndt-server"]
+}

--- a/modules/autojoin/instances.tf
+++ b/modules/autojoin/instances.tf
@@ -15,7 +15,11 @@ resource "google_compute_instance" "autonode" {
     access_config {
       nat_ip = google_compute_address.autonode_ipv4.address
     }
+    ipv6_access_config {
+      network_tier = "PREMIUM"
+    }
     network    = google_compute_network.autojoin.name
+    stack_type = "IPV4_IPV6"
     subnetwork = google_compute_subnetwork.autojoin.name
   }
 


### PR DESCRIPTION
This enables IPv6 on the autonode test VM.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/96)
<!-- Reviewable:end -->
