### PR TITLE
Add static external IP for nginx ingress for autojoin cluster

### DIFF
--- a/modules/autojoin/networking.tf
+++ b/modules/autojoin/networking.tf
@@ -25,3 +25,9 @@ resource "google_compute_subnetwork" "gae" {
   region           = var.appengine_region
   stack_type       = "IPV4_IPV6"
 }
+
+resource "google_compute_address" "autojoin" {
+  name         = "autojoin-ingress-nginx"
+  address_type = "EXTERNAL"
+  description  = "External IP address for ingress-nginx"
+}


### PR DESCRIPTION
This change adds a new static IP declaration to the autojoin module for a nginx ingress loadbalancer configuration for the intended Prometheus instance deployed to the autojoin cluster.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/97)
<!-- Reviewable:end -->
