### PR TITLE
Updates all disk images in sandbox and staging

### DIFF
--- a/mlab-sandbox/platform-cluster.tf
+++ b/mlab-sandbox/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-2024-09-10t21-48-35"
+      disk_image       = "platform-cluster-instance-2024-09-11t17-23-48"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -39,7 +39,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-2024-09-10t21-48-35"
+      disk_image        = "platform-cluster-api-instance-2024-09-11t17-23-48"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -73,7 +73,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-2024-09-10t21-48-35"
+    disk_image        = "platform-cluster-internal-instance-2024-09-11t17-23-48"
     disk_size_gb_boot = 100
     disk_size_gb_data = 200
     disk_type         = "pd-ssd"

--- a/mlab-sandbox/platform-cluster.tf
+++ b/mlab-sandbox/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-2024-08-01t19-51-44"
+      disk_image       = "platform-cluster-instance-2024-09-10t21-48-35"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -39,7 +39,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-2024-08-01t19-51-44"
+      disk_image        = "platform-cluster-api-instance-2024-09-10t21-48-35"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -73,7 +73,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-2024-08-01t19-51-44"
+    disk_image        = "platform-cluster-internal-instance-2024-09-10t21-48-35"
     disk_size_gb_boot = 100
     disk_size_gb_data = 200
     disk_type         = "pd-ssd"

--- a/mlab-staging/platform-cluster.tf
+++ b/mlab-staging/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-2024-08-05t14-53-03"
+      disk_image       = "platform-cluster-instance-2024-09-11t19-56-13"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -38,7 +38,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-2024-08-05t14-53-03"
+      disk_image        = "platform-cluster-api-instance-2024-09-11t19-56-13"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -72,7 +72,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-2024-08-05t14-53-03"
+    disk_image        = "platform-cluster-internal-instance-2024-09-11t19-56-13"
     disk_size_gb_boot = 100
     disk_size_gb_data = 1500
     disk_type         = "pd-ssd"


### PR DESCRIPTION
The new images contain the CNI configurations already baked into them:

https://github.com/m-lab/epoxy-images/pull/268


... and this dovetails with this change in k8s-support:

https://github.com/m-lab/k8s-support/pull/902

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/98)
<!-- Reviewable:end -->
