### PR TITLE
Add roles for artifact/container registry access to autojoin-gke SA

### DIFF
--- a/modules/autojoin/roles.tf
+++ b/modules/autojoin/roles.tf
@@ -1,0 +1,29 @@
+resource "google_storage_bucket_iam_member" "autonode_access" {
+  bucket = "archive-${data.google_client_config.current.project}"
+  role = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.autonode.email}"
+}
+
+resource "google_storage_bucket_iam_member" "autonode_access_downloader" {
+  bucket = "downloader-${data.google_client_config.current.project}"
+  role = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.autonode.email}"
+}
+
+resource "google_project_iam_member" "autonode_gke_artifact_registry_access" {
+  role = "roles/artifactregistry.reader"
+  member = "serviceAccount:${google_service_account.gke.email}"
+  project = data.google_client_config.current.project
+}
+
+resource "google_project_iam_member" "autonode_gke_container_registry_access" {
+  role = "roles/containerregistry.ServiceAgent"
+  member = "serviceAccount:${google_service_account.gke.email}"
+  project = data.google_client_config.current.project
+}
+
+resource "google_project_iam_member" "autonode_gke_default_node_permissions" {
+  role = "roles/container.defaultNodeServiceAccount"
+  member = "serviceAccount:${google_service_account.gke.email}"
+  project = data.google_client_config.current.project
+}

--- a/modules/autojoin/serviceaccounts.tf
+++ b/modules/autojoin/serviceaccounts.tf
@@ -9,27 +9,3 @@ resource "google_service_account" "gke" {
   description = "Default SA for the autojoin GKE cluster node pools (managed by Terraform)"
   display_name = "Autojoin GKE SA"
 }
-
-resource "google_project_iam_member" "autonode_gke_artifact_registry_access" {
-  role = "roles/artifactregistry.reader"
-  member = "serviceAccount:${google_service_account.gke.email}"
-  project = data.google_client_config.current.project
-}
-
-resource "google_project_iam_member" "autonode_gke_container_registry_access" {
-  role = "roles/containerregistry.ServiceAgent"
-  member = "serviceAccount:${google_service_account.gke.email}"
-  project = data.google_client_config.current.project
-}
-
-resource "google_storage_bucket_iam_member" "autonode_access" {
-  bucket = "archive-${data.google_client_config.current.project}"
-  role = "roles/storage.objectAdmin"
-  member = "serviceAccount:${google_service_account.autonode.email}"
-}
-
-resource "google_storage_bucket_iam_member" "autonode_access_downloader" {
-  bucket = "downloader-${data.google_client_config.current.project}"
-  role = "roles/storage.objectViewer"
-  member = "serviceAccount:${google_service_account.autonode.email}"
-}

--- a/modules/autojoin/serviceaccounts.tf
+++ b/modules/autojoin/serviceaccounts.tf
@@ -10,6 +10,18 @@ resource "google_service_account" "gke" {
   display_name = "Autojoin GKE SA"
 }
 
+resource "google_project_iam_member" "autonode_gke_artifact_registry_access" {
+  role = "roles/artifactregistry.reader"
+  member = "serviceAccount:${google_service_account.gke.email}"
+  project = data.google_client_config.current.project
+}
+
+resource "google_project_iam_member" "autonode_gke_container_registry_access" {
+  role = "roles/containerregistry.ServiceAgent"
+  member = "serviceAccount:${google_service_account.gke.email}"
+  project = data.google_client_config.current.project
+}
+
 resource "google_storage_bucket_iam_member" "autonode_access" {
   bucket = "archive-${data.google_client_config.current.project}"
   role = "roles/storage.objectAdmin"


### PR DESCRIPTION
These are needed so that nodes in the autojoin GKE cluster can pull images. Until we migrate fully to Artifact registry, both roles are needed. Role definitions have been moved to a new file (roles.tf) to keep them distinct from service accounts (serviceaccounts.tf).

Also, the autojoin-gke role was missing the most basic role for a GKE node SA (`container.defaultNodeServiceAccount`) which I also added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/100)
<!-- Reviewable:end -->
