### PR TITLE
Add GCS and BigQuery roles for autoloader to autojoin service accounts

### DIFF
--- a/modules/autojoin/roles.tf
+++ b/modules/autojoin/roles.tf
@@ -55,3 +55,9 @@ resource "google_project_iam_member" "autonode_gke_bigquery_updater" {
   member = "serviceAccount:${google_service_account.gke.email}"
   project = data.google_client_config.current.project
 }
+
+resource "google_project_iam_member" "autonode_gke_bigquery_user" {
+  role = "roles/bigquery.user"
+  member = "serviceAccount:${google_service_account.gke.email}"
+  project = data.google_client_config.current.project
+}

--- a/modules/autojoin/roles.tf
+++ b/modules/autojoin/roles.tf
@@ -1,3 +1,19 @@
+resource "google_project_iam_custom_role" "autoloader_gcs_reader" {
+  description = "autolaoder-gcs-reader"
+  # NOTE: permissions mirror the set used by legacy reader, a role that cannot
+  # be assigned to service accounts.
+  permissions = [
+    "storage.buckets.get",
+    "storage.managedFolders.get",
+    "storage.managedFolders.list",
+    "storage.multipartUploads.list",
+    "storage.objects.list",
+  ]
+  role_id     = "autoloader_gcs_access"
+  stage       = "GA"
+  title       = "autoloader-gcs-reader"
+}
+
 resource "google_storage_bucket_iam_member" "autonode_access" {
   bucket = "archive-${data.google_client_config.current.project}"
   role = "roles/storage.objectAdmin"
@@ -29,10 +45,7 @@ resource "google_project_iam_member" "autonode_gke_default_node_permissions" {
 }
 
 resource "google_project_iam_member" "autonode_gke_gcs_reader" {
-  # TODO(soltesz): use a custom role with significantly lower permissions.
-  # At this time, legacy roles cannot be assigned to service accounts and there
-  # is no other suitable predefined role with storage.buckets.get
-  role = "roles/storage.admin"
+  role = "${google_project_iam_custom_role.autoloader_gcs_reader.id}"
   member = "serviceAccount:${google_service_account.gke.email}"
   project = data.google_client_config.current.project
 }

--- a/modules/autojoin/roles.tf
+++ b/modules/autojoin/roles.tf
@@ -51,7 +51,7 @@ resource "google_project_iam_member" "autonode_gke_gcs_reader" {
 }
 
 resource "google_project_iam_member" "autonode_gke_bigquery_updater" {
-  role = "roles/bigquery.user"
+  role = "roles/bigquery.dataEditor"
   member = "serviceAccount:${google_service_account.gke.email}"
   project = data.google_client_config.current.project
 }

--- a/modules/autojoin/roles.tf
+++ b/modules/autojoin/roles.tf
@@ -29,7 +29,10 @@ resource "google_project_iam_member" "autonode_gke_default_node_permissions" {
 }
 
 resource "google_project_iam_member" "autonode_gke_gcs_reader" {
-  role = "roles/storage.legacyBucketReader"
+  # TODO(soltesz): use a custom role with significantly lower permissions.
+  # At this time, legacy roles cannot be assigned to service accounts and there
+  # is no other suitable predefined role with storage.buckets.get
+  role = "roles/storage.admin"
   member = "serviceAccount:${google_service_account.gke.email}"
   project = data.google_client_config.current.project
 }

--- a/modules/autojoin/roles.tf
+++ b/modules/autojoin/roles.tf
@@ -27,3 +27,15 @@ resource "google_project_iam_member" "autonode_gke_default_node_permissions" {
   member = "serviceAccount:${google_service_account.gke.email}"
   project = data.google_client_config.current.project
 }
+
+resource "google_project_iam_member" "autonode_gke_gcs_reader" {
+  role = "roles/storage.legacyBucketReader"
+  member = "serviceAccount:${google_service_account.gke.email}"
+  project = data.google_client_config.current.project
+}
+
+resource "google_project_iam_member" "autonode_gke_bigquery_updater" {
+  role = "roles/bigquery.user"
+  member = "serviceAccount:${google_service_account.gke.email}"
+  project = data.google_client_config.current.project
+}

--- a/modules/autojoin/variables.tf
+++ b/modules/autojoin/variables.tf
@@ -1,6 +1,6 @@
 variable "node_pools" {
   default = {
-    "pipeline" = {
+    "processor" = {
       initial_node_count = 1
       machine_type       = "n2-standard-4"
       max_node_count     = 3


### PR DESCRIPTION
This change builds on https://github.com/m-lab/terraform-support/pull/100 by adding two new roles for the `autoloader` service that run on the GKE autojoin cluster to read from GCS and write to BigQuery.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/101)
<!-- Reviewable:end -->
