### PR TITLE
Change name of monitoring node pool in data-pipeline to "monitoring"

### DIFF
--- a/mlab-sandbox/data-pipeline.tf
+++ b/mlab-sandbox/data-pipeline.tf
@@ -44,7 +44,7 @@ module "data-pipeline" {
         "https://www.googleapis.com/auth/taskqueue"
       ]
     },
-    "prometheus" = {
+    "monitoring" = {
       initial_node_count = 1
       machine_type       = "n2-standard-4"
       max_node_count     = 2


### PR DESCRIPTION
This will bring the node pool name and node labels in line with the nodeSelector added to the prometheus and kube-state-metrics pods in prometheus-support:

https://github.com/m-lab/prometheus-support/blob/main/k8s/data-pipeline/deployments/kube-state-metrics.yml#L18
https://github.com/m-lab/prometheus-support/blob/main/k8s/data-pipeline/deployments/prometheus.yml#L45

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/103)
<!-- Reviewable:end -->
