### PR TITLE
Changes all other monitoring node pools form "prometheus" to "monitoring"

### DIFF
--- a/mlab-autojoin/data-pipeline.tf
+++ b/mlab-autojoin/data-pipeline.tf
@@ -22,7 +22,7 @@ module "data-pipeline" {
         "https://www.googleapis.com/auth/taskqueue"
       ]
     },
-    "prometheus" = {
+    "monitoring" = {
       initial_node_count = 1
       machine_type       = "n2-standard-4"
       max_node_count     = 2

--- a/mlab-oti/data-pipeline.tf
+++ b/mlab-oti/data-pipeline.tf
@@ -44,7 +44,7 @@ module "data-pipeline" {
         "https://www.googleapis.com/auth/taskqueue"
       ]
     },
-    "prometheus" = {
+    "monitoring" = {
       initial_node_count = 1
       machine_type       = "n2-standard-4"
       max_node_count     = 2

--- a/mlab-staging/data-pipeline.tf
+++ b/mlab-staging/data-pipeline.tf
@@ -44,7 +44,7 @@ module "data-pipeline" {
         "https://www.googleapis.com/auth/taskqueue"
       ]
     },
-    "prometheus" = {
+    "monitoring" = {
       initial_node_count = 1
       machine_type       = "n2-standard-4"
       max_node_count     = 2


### PR DESCRIPTION
In commit @5df0154 I accidentally only made the node pool name change for mlab-sandbox. This commit makes the same update in all other projects.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/104)
<!-- Reviewable:end -->
