### PR TITLE
Add icmp to autonode firewall

### DIFF
--- a/modules/autojoin/firewall.tf
+++ b/modules/autojoin/firewall.tf
@@ -48,7 +48,7 @@ resource "google_compute_firewall" "ndt_access_ipv6" {
     protocol = "tcp"
   }
   allow {
-    protocol = "ipv6-icmp"
+    protocol = "58" # NOTE: there is no recognized protocol name for ipv6-icmp.
   }
 
   description   = "Allow IPv6 access to NDT servers"

--- a/modules/autojoin/firewall.tf
+++ b/modules/autojoin/firewall.tf
@@ -48,7 +48,7 @@ resource "google_compute_firewall" "ndt_access_ipv6" {
     protocol = "tcp"
   }
   allow {
-    protocol = "58"
+    protocol = "ipv6-icmp"
   }
 
   description   = "Allow IPv6 access to NDT servers"

--- a/modules/autojoin/firewall.tf
+++ b/modules/autojoin/firewall.tf
@@ -48,7 +48,7 @@ resource "google_compute_firewall" "ndt_access_ipv6" {
     protocol = "tcp"
   }
   allow {
-    protocol = "icmpv6"
+    protocol = "icmp"
   }
 
   description   = "Allow IPv6 access to NDT servers"

--- a/modules/autojoin/firewall.tf
+++ b/modules/autojoin/firewall.tf
@@ -16,7 +16,7 @@ resource "google_compute_firewall" "public_prometheus_monitoring" {
     ports    = ["9990-9999"]
     protocol = "tcp"
   }
-  
+
   description   = "Allow open access to prometheus metrics on select servers"
   name          = "public-prometheus-monitoring"
   network       = google_compute_network.autojoin.name
@@ -30,7 +30,10 @@ resource "google_compute_firewall" "ndt_access" {
     ports    = ["80", "443"]
     protocol = "tcp"
   }
-  
+  allow {
+    protocol = "icmp"
+  }
+
   description   = "Allow access to NDT servers"
   name          = "ndt-access"
   network       = google_compute_network.autojoin.name
@@ -43,6 +46,9 @@ resource "google_compute_firewall" "ndt_access_ipv6" {
   allow {
     ports    = ["80", "443"]
     protocol = "tcp"
+  }
+  allow {
+    protocol = "icmpv6"
   }
 
   description   = "Allow IPv6 access to NDT servers"

--- a/modules/autojoin/firewall.tf
+++ b/modules/autojoin/firewall.tf
@@ -48,7 +48,7 @@ resource "google_compute_firewall" "ndt_access_ipv6" {
     protocol = "tcp"
   }
   allow {
-    protocol = "icmp"
+    protocol = "58"
   }
 
   description   = "Allow IPv6 access to NDT servers"


### PR DESCRIPTION
This change adds icmp to the ndt-server firewall rule used by the autonode VMs. By allowing icmp we can run traceroute-caller.

While the web ui reports protocol 58 as "ipv6-icmp", this value in the terraform config generates this error:

```
Error: Error updating Firewall "projects/mlab-sandbox/global/firewalls/ndt-access-ipv6": googleapi: 
Error 400: Invalid value for field 'resource.allowed[1].IPProtocol': 'ipv6-icmp'. Must be one of 
["ah", "all", "esp", "icmp", "ipip", "sctp", "tcp", "udp"] or an IP protocol number between 0 and 255., invalid
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/105)
<!-- Reviewable:end -->
