### PR TITLE
Move autojoin zone to us-central1-c

### DIFF
--- a/mlab-autojoin/main.tf
+++ b/mlab-autojoin/main.tf
@@ -42,5 +42,5 @@ provider "google" {
   alias   = "autojoin"
   project = "mlab-autojoin"
   region  = "us-central1"
-  zone    = "us-central1-a"
+  zone    = "us-central1-c"
 }

--- a/mlab-sandbox/main.tf
+++ b/mlab-sandbox/main.tf
@@ -42,5 +42,5 @@ provider "google" {
   alias   = "autojoin"
   project = "mlab-sandbox"
   region  = "us-central1"
-  zone    = "us-central1-a"
+  zone    = "us-central1-c"
 }

--- a/mlab-staging/main.tf
+++ b/mlab-staging/main.tf
@@ -42,5 +42,5 @@ provider "google" {
   alias   = "autojoin"
   project = "mlab-staging"
   region  = "us-central1"
-  zone    = "us-central1-a"
+  zone    = "us-central1-c"
 }


### PR DESCRIPTION
This change intends to move the autonode instance to the same GCE zone as the monitoring cluster so transfers between VMs are zero cost.

NOTE: the original autonode VM must be manually removed and recreated by terraform to be placed in the new zone.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/106)
<!-- Reviewable:end -->
