### PR TITLE
Update OS for autonode

### DIFF
--- a/modules/autojoin/instances.tf
+++ b/modules/autojoin/instances.tf
@@ -2,7 +2,7 @@ resource "google_compute_instance" "autonode" {
   boot_disk {
     auto_delete = false
     initialize_params {
-      image = "ubuntu-minimal-2204-lts"
+      image = "ubuntu-minimal-2404-lts-amd64"
     }
   }
 


### PR DESCRIPTION
This change updates the mlab autonode OS image to the latest LTS version of ubuntu.

This change is to help diagnose and debug typical operating environments of other autonode hosts.