### PR TITLE
Add new autojoin firewall rule to allow monitoring of AppEngine

### DIFF
--- a/modules/autojoin/firewall.tf
+++ b/modules/autojoin/firewall.tf
@@ -35,6 +35,7 @@ resource "google_compute_firewall" "appengine_prometheus_monitoring" {
   name          = "appengine-prometheus-monitoring"
   network       = google_compute_network.autojoin.name
   source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["autojoin"]
 }
 
 # Allow access to NDT servers on ports 80/443

--- a/modules/autojoin/firewall.tf
+++ b/modules/autojoin/firewall.tf
@@ -24,6 +24,19 @@ resource "google_compute_firewall" "public_prometheus_monitoring" {
   target_tags   = ["public-prometheus-monitoring"]
 }
 
+# Allow Prometheus to scrape metrics from Autojoin AppEngine instances
+resource "google_compute_firewall" "appengine_prometheus_monitoring" {
+  allow {
+    ports    = ["9090"]
+    protocol = "tcp"
+  }
+
+  description   = "Allow Prometheus to scrape metrics from Autjoin AppEngine instances"
+  name          = "appengine-prometheus-monitoring"
+  network       = google_compute_network.autojoin.name
+  source_ranges = ["0.0.0.0/0"]
+}
+
 # Allow access to NDT servers on ports 80/443
 resource "google_compute_firewall" "ndt_access" {
   allow {


### PR DESCRIPTION
This new rule allows anyone to scrape port 9090 of instances created by the autojoin AppEngine service. Monitoring of the autojoin API has been broken since August 21, and this resolves the issue. This rule does not allow people to scrape Prometheus using the public AppEngine URLs (e.g., https://autojoin-dot-mlab-sandbox.appspot.com), but only the public addresses of the instances that back the service. It may not be easy for someone to discover those IP addresses. In any case, the Prometheus metrics are not sensitive, and this is how Prometheus works with the Locate AppEngine service too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/110)
<!-- Reviewable:end -->
