### PR TITLE
Add appengine.appViewer permission to autojoin GKE service account

### DIFF
--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-v2-4-21"
+      disk_image       = "platform-cluster-instance-v2-4-23"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -219,7 +219,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-v2-4-21"
+      disk_image        = "platform-cluster-api-instance-v2-4-23"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -253,7 +253,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-v2-4-21"
+    disk_image        = "platform-cluster-internal-instance-v2-4-23"
     disk_size_gb_boot = 100
     disk_size_gb_data = 3500
     disk_type         = "pd-ssd"

--- a/mlab-sandbox/platform-cluster.tf
+++ b/mlab-sandbox/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-2024-12-05t19-09-37"
+      disk_image       = "platform-cluster-instance-2025-02-06t20-05-23"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -45,7 +45,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-2024-12-05t19-09-37"
+      disk_image        = "platform-cluster-api-instance-2025-02-06t20-05-23"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -79,7 +79,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-2024-12-05t19-09-37"
+    disk_image        = "platform-cluster-internal-instance-2025-02-06t20-05-23"
     disk_size_gb_boot = 100
     disk_size_gb_data = 200
     disk_type         = "pd-ssd"

--- a/mlab-sandbox/platform-cluster.tf
+++ b/mlab-sandbox/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-2025-02-06t20-05-23"
+      disk_image       = "platform-cluster-instance-2025-02-25t21-30-43"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -45,7 +45,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-2025-02-06t20-05-23"
+      disk_image        = "platform-cluster-api-instance-2025-02-25t21-30-43"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -79,7 +79,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-2025-02-06t20-05-23"
+    disk_image        = "platform-cluster-internal-instance-2025-02-25t21-30-43"
     disk_size_gb_boot = 100
     disk_size_gb_data = 200
     disk_type         = "pd-ssd"

--- a/mlab-staging/platform-cluster.tf
+++ b/mlab-staging/platform-cluster.tf
@@ -8,7 +8,7 @@ module "platform-cluster" {
   instances = {
     attributes = {
       daemonset        = "ndt"
-      disk_image       = "platform-cluster-instance-2024-09-18t21-40-07"
+      disk_image       = "platform-cluster-instance-2025-02-26t16-53-00"
       disk_size_gb     = 100
       disk_type        = "pd-ssd"
       machine_type     = "n2-highcpu-4"
@@ -40,7 +40,7 @@ module "platform-cluster" {
 
   api_instances = {
     machine_attributes = {
-      disk_image        = "platform-cluster-api-instance-2024-09-18t21-40-07"
+      disk_image        = "platform-cluster-api-instance-2025-02-26t16-53-00"
       disk_size_gb_boot = 100
       disk_size_gb_data = 10
       # This will show up as /dev/disk/by-id/google-<name>
@@ -74,7 +74,7 @@ module "platform-cluster" {
   }
 
   prometheus_instance = {
-    disk_image        = "platform-cluster-internal-instance-2024-09-18t21-40-07"
+    disk_image        = "platform-cluster-internal-instance-2025-02-26t16-53-00"
     disk_size_gb_boot = 100
     disk_size_gb_data = 1500
     disk_type         = "pd-ssd"

--- a/modules/autojoin/firewall.tf
+++ b/modules/autojoin/firewall.tf
@@ -13,7 +13,7 @@ resource "google_compute_firewall" "iap_access" {
 # Allow open access to prometheus metrics on select servers
 resource "google_compute_firewall" "public_prometheus_monitoring" {
   allow {
-    ports    = ["9100", "9990-9999"]
+    ports    = ["9990-9999"]
     protocol = "tcp"
   }
 

--- a/modules/autojoin/firewall.tf
+++ b/modules/autojoin/firewall.tf
@@ -13,7 +13,7 @@ resource "google_compute_firewall" "iap_access" {
 # Allow open access to prometheus metrics on select servers
 resource "google_compute_firewall" "public_prometheus_monitoring" {
   allow {
-    ports    = ["9990-9999"]
+    ports    = ["9100", "9990-9999"]
     protocol = "tcp"
   }
 

--- a/modules/autojoin/roles.tf
+++ b/modules/autojoin/roles.tf
@@ -62,3 +62,9 @@ resource "google_project_iam_member" "autonode_gke_bigquery_user" {
   project = data.google_client_config.current.project
 }
 
+resource "google_project_iam_member" "autonode_gke_appengine_viewer" {
+  role = "roles/appengine.appViewer"
+  member = "serviceAccount:${google_service_account.gke.email}"
+  project = data.google_client_config.current.project
+}
+

--- a/modules/autojoin/roles.tf
+++ b/modules/autojoin/roles.tf
@@ -61,3 +61,10 @@ resource "google_project_iam_member" "autonode_gke_bigquery_user" {
   member = "serviceAccount:${google_service_account.gke.email}"
   project = data.google_client_config.current.project
 }
+
+resource "google_project_iam_member" "autonode_gke_bigquery_viewer" {
+  role = "roles/bigquery.dataViewer"
+  member = "serviceAccount:${google_service_account.gke.email}"
+  project = data.google_client_config.current.project
+}
+

--- a/modules/autojoin/roles.tf
+++ b/modules/autojoin/roles.tf
@@ -62,9 +62,3 @@ resource "google_project_iam_member" "autonode_gke_bigquery_user" {
   project = data.google_client_config.current.project
 }
 
-resource "google_project_iam_member" "autonode_gke_bigquery_viewer" {
-  role = "roles/bigquery.dataViewer"
-  member = "serviceAccount:${google_service_account.gke.email}"
-  project = data.google_client_config.current.project
-}
-


### PR DESCRIPTION
It needs it for gcp-service-discovery to be able to scrape metrics from App Engine Flex machines.

Also, updates disk images for all projects.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/112)
<!-- Reviewable:end -->
