### PR TITLE
Adds balancing_mode to platform_cluster_mig_backends

### DIFF
--- a/modules/platform-cluster/loadbalancers.tf
+++ b/modules/platform-cluster/loadbalancers.tf
@@ -35,7 +35,8 @@ resource "google_compute_region_backend_service" "platform_cluster_mig_backends"
   for_each = { for k, v in var.instances.migs : k => v if v.loadbalanced }
 
   backend {
-    group = google_compute_region_instance_group_manager.platform_cluster_mig_managers[each.key].instance_group
+    balancing_mode = "CONNECTION"
+    group          = google_compute_region_instance_group_manager.platform_cluster_mig_managers[each.key].instance_group
   }
 
   name                  = "${each.key}-${data.google_client_config.current.project}-measurement-lab-org"


### PR DESCRIPTION
This was already added to a few other region_backend_service definitions, but I failed to add it to this one as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/116)
<!-- Reviewable:end -->
