### PR TITLE
Increase M-Lab test autonode boot disks from 10GB to 100GB

### DIFF
--- a/modules/autojoin/instances.tf
+++ b/modules/autojoin/instances.tf
@@ -1,7 +1,7 @@
 resource "google_compute_instance" "autonode" {
   boot_disk {
     auto_delete = true
-    source      = google_compute_disk.autonode_boot_disk
+    source      = google_compute_disk.autonode_boot_disk.id
   }
 
   description             = "Automated deployment and testing of the autonode Docker compose (managed by Terraform)"

--- a/modules/autojoin/instances.tf
+++ b/modules/autojoin/instances.tf
@@ -1,9 +1,7 @@
 resource "google_compute_instance" "autonode" {
   boot_disk {
     auto_delete = true
-    initialize_params {
-      image = "ubuntu-minimal-2404-lts-amd64"
-    }
+    source      = google_compute_disk.autonode_boot_disk
   }
 
   description             = "Automated deployment and testing of the autonode Docker compose (managed by Terraform)"
@@ -29,4 +27,11 @@ resource "google_compute_instance" "autonode" {
   }
 
   tags = ["ndt-server", "public-prometheus-monitoring"]
+}
+
+resource "google_compute_disk" "autonode_boot_disk" {
+  image = "ubuntu-minimal-2404-lts-amd64"
+  name  = "autonode-boot-disk"
+  size  = "100"
+  type  = "pd-ssd"
 }


### PR DESCRIPTION
10GB is not enough, and eventually the root filesystem will fill up and break everything running on the machine. 100GB should be plenty to never have run out of space, as long as k8s and things truncate/prune/rotate log files as they should.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/119)
<!-- Reviewable:end -->
