### PR TITLE
feat(foundations): add orgadm IAM roles and fix visualizations bindings

### DIFF
--- a/mlab-autojoin/foundations.tf
+++ b/mlab-autojoin/foundations.tf
@@ -1,0 +1,7 @@
+module "foundations" {
+  source = "../modules/foundations"
+
+  providers = {
+    google = google.foundations
+  }
+}

--- a/modules/foundations/iam.tf
+++ b/modules/foundations/iam.tf
@@ -23,9 +23,23 @@ resource "google_project_iam_custom_role" "orgadm_operator" {
 resource "google_project_iam_custom_role" "orgadm_credentials" {
   description = "Permissions to manage orgadm platform credentials in Datastore"
   permissions = [
+    "appengine.applications.get",
+    "databasesconsole.locations.get",
+    "databasesconsole.locations.list",
+    "datastore.databases.get",
+    "datastore.databases.getMetadata",
+    "datastore.databases.list",
+    "datastore.entities.allocateIds",
     "datastore.entities.create",
     "datastore.entities.get",
     "datastore.entities.list",
+    "datastore.entities.update",
+    "datastore.namespaces.get",
+    "datastore.namespaces.list",
+    "datastore.schemas.list",
+    "datastore.statistics.get",
+    "datastore.statistics.list",
+    "resourcemanager.projects.get",
   ]
   role_id = "orgadm_credentials"
   stage   = "GA"

--- a/modules/foundations/iam.tf
+++ b/modules/foundations/iam.tf
@@ -1,0 +1,33 @@
+resource "google_project_iam_custom_role" "orgadm_operator" {
+  description = "Permissions to run orgadm for BYOS onboarding (service accounts, secrets, DNS, IAM)"
+  permissions = [
+    "dns.changes.create",
+    "dns.managedZones.create",
+    "dns.managedZones.get",
+    "dns.resourceRecordSets.get",
+    "iam.serviceAccountKeys.create",
+    "iam.serviceAccounts.create",
+    "iam.serviceAccounts.get",
+    "resourcemanager.projects.getIamPolicy",
+    "resourcemanager.projects.setIamPolicy",
+    "secretmanager.secrets.create",
+    "secretmanager.secrets.get",
+    "secretmanager.versions.access",
+    "secretmanager.versions.add",
+  ]
+  role_id = "orgadm_operator"
+  stage   = "GA"
+  title   = "orgadm-operator"
+}
+
+resource "google_project_iam_custom_role" "orgadm_credentials" {
+  description = "Permissions to manage orgadm platform credentials in Datastore"
+  permissions = [
+    "datastore.entities.create",
+    "datastore.entities.get",
+    "datastore.entities.list",
+  ]
+  role_id = "orgadm_credentials"
+  stage   = "GA"
+  title   = "orgadm-credentials"
+}

--- a/modules/foundations/main.tf
+++ b/modules/foundations/main.tf
@@ -6,3 +6,5 @@ terraform {
   }
 }
 
+data "google_client_config" "current" {}
+

--- a/modules/visualizations/serviceaccounts.tf
+++ b/modules/visualizations/serviceaccounts.tf
@@ -10,56 +10,38 @@ resource "google_service_account" "grafana_public" {
 #
 # Role Bindings
 #
-resource "google_project_iam_binding" "logging_logwriter" {
+resource "google_project_iam_member" "logging_logwriter" {
   project = data.google_project.current.id
   role    = "roles/logging.logWriter"
-
-  members = [
-    "serviceAccount:grafana-public@${data.google_project.current.project_id}.iam.gserviceaccount.com"
-  ]
+  member  = "serviceAccount:grafana-public@${data.google_project.current.project_id}.iam.gserviceaccount.com"
 }
 
-resource "google_project_iam_binding" "cloudtrace_agent" {
+resource "google_project_iam_member" "cloudtrace_agent" {
   project = data.google_project.current.id
   role    = "roles/cloudtrace.agent"
-
-  members = [
-    "serviceAccount:grafana-public@${data.google_project.current.project_id}.iam.gserviceaccount.com"
-  ]
+  member  = "serviceAccount:grafana-public@${data.google_project.current.project_id}.iam.gserviceaccount.com"
 }
 
-resource "google_project_iam_binding" "monitoring_metricwriter" {
+resource "google_project_iam_member" "monitoring_metricwriter" {
   project = data.google_project.current.id
   role    = "roles/monitoring.metricWriter"
-
-  members = [
-    "serviceAccount:grafana-public@${data.google_project.current.project_id}.iam.gserviceaccount.com"
-  ]
+  member  = "serviceAccount:grafana-public@${data.google_project.current.project_id}.iam.gserviceaccount.com"
 }
 
-resource "google_project_iam_binding" "monitoring_metricsscopesviewer" {
+resource "google_project_iam_member" "monitoring_metricsscopesviewer" {
   project = data.google_project.current.id
   role    = "roles/monitoring.metricsScopesViewer"
-
-  members = [
-    "serviceAccount:grafana-public@${data.google_project.current.project_id}.iam.gserviceaccount.com"
-  ]
+  member  = "serviceAccount:grafana-public@${data.google_project.current.project_id}.iam.gserviceaccount.com"
 }
 
-resource "google_project_iam_binding" "storage_objectviewer" {
+resource "google_project_iam_member" "storage_objectviewer" {
   project = data.google_project.current.id
   role    = "roles/storage.objectViewer"
-
-  members = [
-    "serviceAccount:grafana-public@${data.google_project.current.project_id}.iam.gserviceaccount.com"
-  ]
+  member  = "serviceAccount:grafana-public@${data.google_project.current.project_id}.iam.gserviceaccount.com"
 }
 
-resource "google_project_iam_binding" "artifactregistry_reader" {
+resource "google_project_iam_member" "artifactregistry_reader" {
   project = data.google_project.current.id
   role    = "roles/artifactregistry.reader"
-
-  members = [
-    "serviceAccount:grafana-public@${data.google_project.current.project_id}.iam.gserviceaccount.com"
-  ]
+  member  = "serviceAccount:grafana-public@${data.google_project.current.project_id}.iam.gserviceaccount.com"
 }


### PR DESCRIPTION
## Summary

- Add custom IAM roles (`orgadm_operator`, `orgadm_credentials`) for BYOS onboarding in the foundations module
- Instantiate the foundations module in `mlab-autojoin`
- Convert `google_project_iam_binding` to `google_project_iam_member` in the visualizations module to eliminate conflicts with the autojoin module's `roles/artifactregistry.reader` member

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/133)
<!-- Reviewable:end -->
