### PR TITLE
Creates new monitoring submodule

### DIFF
--- a/mlab-sandbox/main.tf
+++ b/mlab-sandbox/main.tf
@@ -51,3 +51,10 @@ provider "google" {
   region  = "us-central1"
   zone    = "us-central1-c"
 }
+
+provider "google" {
+  alias   = "monitoring"
+  project = "mlab-sandbox"
+  region  = "us-central1"
+  zone    = "us-central1-c"
+}

--- a/mlab-sandbox/monitoring.tf
+++ b/mlab-sandbox/monitoring.tf
@@ -1,0 +1,11 @@
+module "monitoring" {
+  source = "../modules/monitoring"
+
+  providers = {
+    google = google.monitoring
+  }
+
+  region      = "us-central1"
+  zone        = "us-central1-c"
+  subnet_cidr = "10.5.0.0/16"
+}

--- a/modules/monitoring/data.tf
+++ b/modules/monitoring/data.tf
@@ -1,0 +1,1 @@
+data "google_project" "project" {}

--- a/modules/monitoring/firewall.tf
+++ b/modules/monitoring/firewall.tf
@@ -1,0 +1,25 @@
+# Allow IAP to SSH into the monitoring VM for config deployment.
+resource "google_compute_firewall" "monitoring_iap_ssh" {
+  allow {
+    ports    = ["22"]
+    protocol = "tcp"
+  }
+  description   = "Allow IAP to SSH into the monitoring VM (managed by Terraform)"
+  name          = "monitoring-iap-ssh"
+  network       = "mlab-platform-network"
+  source_ranges = ["35.235.240.0/20"]
+  target_tags   = ["monitoring"]
+}
+
+# Allow Prometheus to scrape the monitoring VM via its external IPv4 address.
+resource "google_compute_firewall" "monitoring_scrape" {
+  allow {
+    ports    = ["9115"]
+    protocol = "tcp"
+  }
+  description   = "Allow Prometheus to scrape the monitoring VM (managed by Terraform)"
+  name          = "monitoring-scrape"
+  network       = "mlab-platform-network"
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["monitoring"]
+}

--- a/modules/monitoring/iam.tf
+++ b/modules/monitoring/iam.tf
@@ -1,0 +1,8 @@
+# Allow the Cloud Build service account to IAP-tunnel into the monitoring VM
+# for config deployment.
+resource "google_iap_tunnel_instance_iam_member" "cloudbuild" {
+  instance = google_compute_instance.monitoring.name
+  member   = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+  role     = "roles/iap.tunnelResourceAccessor"
+  zone     = var.zone
+}

--- a/modules/monitoring/instance.tf
+++ b/modules/monitoring/instance.tf
@@ -1,0 +1,31 @@
+resource "google_compute_instance" "monitoring" {
+  allow_stopping_for_update = true
+  description               = "VM for external network monitoring probes (managed by Terraform)"
+  machine_type              = "e2-micro"
+  name                      = "ipv6-monitoring"
+  zone                      = var.zone
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-minimal-2404-lts-amd64"
+      size  = 20
+      type  = "pd-standard"
+    }
+  }
+
+  metadata_startup_script = file("${path.root}/../scripts/install-docker.sh")
+
+  network_interface {
+    access_config {
+      nat_ip = google_compute_address.monitoring_ipv4.address
+    }
+    ipv6_access_config {
+      network_tier = "PREMIUM"
+    }
+    network    = "mlab-platform-network"
+    stack_type = "IPV4_IPV6"
+    subnetwork = google_compute_subnetwork.monitoring.name
+  }
+
+  tags = ["monitoring"]
+}

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}

--- a/modules/monitoring/networking.tf
+++ b/modules/monitoring/networking.tf
@@ -1,0 +1,14 @@
+resource "google_compute_subnetwork" "monitoring" {
+  ip_cidr_range    = var.subnet_cidr
+  ipv6_access_type = "EXTERNAL"
+  name             = "monitoring"
+  network          = "mlab-platform-network"
+  region           = var.region
+  stack_type       = "IPV4_IPV6"
+}
+
+resource "google_compute_address" "monitoring_ipv4" {
+  description = "Static external IPv4 address for the monitoring VM (managed by Terraform)"
+  name        = "monitoring-ipv4"
+  region      = var.region
+}

--- a/modules/monitoring/variables.tf
+++ b/modules/monitoring/variables.tf
@@ -1,0 +1,14 @@
+variable "region" {
+  description = "GCP region for the monitoring VM and subnet"
+  type        = string
+}
+
+variable "zone" {
+  description = "GCP zone for the monitoring VM"
+  type        = string
+}
+
+variable "subnet_cidr" {
+  description = "IPv4 CIDR for the monitoring subnet (must not overlap with existing subnets in the default network)"
+  type        = string
+}

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,8 @@ terraform {
         google.foundations,
         google.platform-cluster,
         google.visualizations,
-        google.google-oim
+        google.google-oim,
+        google.monitoring
       ]
     }
   }


### PR DESCRIPTION
This new submodule will contain all GCP resources related to monitoring in general. Specifically, and for now, this new module creates a new GCE instance that will be responsible for running blackbox_exporter for IPv6 monitoring. This VM and the ones that will eventually come to mlab-staging and mlab-oti are going to replace the Linode IPv6 monitoring VM. That Linode VM was created in the days before GCE supported IPv6, but today GCE fully supports IPv6 so monitoring for it is being folded into GCP rather remaining detached in a Linode unnecessarily.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/134)
<!-- Reviewable:end -->
