### PR TITLE
Adds new monitoring module to staging and production

### DIFF
--- a/mlab-oti/main.tf
+++ b/mlab-oti/main.tf
@@ -45,3 +45,10 @@ provider "google" {
   zone    = "us-central1-a"
 }
 
+provider "google" {
+  alias   = "monitoring"
+  project = "mlab-oti"
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}
+

--- a/mlab-oti/monitoring.tf
+++ b/mlab-oti/monitoring.tf
@@ -1,0 +1,12 @@
+module "monitoring" {
+  source = "../modules/monitoring"
+
+  providers = {
+    google = google.monitoring
+  }
+
+  region      = "us-central1"
+  zone        = "us-central1-a"
+  subnet_cidr = "10.41.0.0/16"
+}
+

--- a/mlab-staging/main.tf
+++ b/mlab-staging/main.tf
@@ -52,3 +52,10 @@ provider "google" {
   zone    = "us-central1-c"
 }
 
+provider "google" {
+  alias   = "monitoring"
+  project = "mlab-staging"
+  region  = "us-central1"
+  zone    = "us-central1-b"
+}
+

--- a/mlab-staging/monitoring.tf
+++ b/mlab-staging/monitoring.tf
@@ -1,0 +1,12 @@
+module "monitoring" {
+  source = "../modules/monitoring"
+
+  providers = {
+    google = google.monitoring
+  }
+
+  region      = "us-central1"
+  zone        = "us-central1-b"
+  subnet_cidr = "10.5.0.0/16"
+}
+


### PR DESCRIPTION
Deploy new VMs in staging and production that are dedicated to IPv6 monitoring, replacing the Linode VM that has been doing the same for the past 8 or so years.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/135)
<!-- Reviewable:end -->
