### PR TITLE
Adds 9100 to allowed ports for IPv6 monitoring VMs

### DIFF
--- a/modules/monitoring/firewall.tf
+++ b/modules/monitoring/firewall.tf
@@ -14,7 +14,7 @@ resource "google_compute_firewall" "monitoring_iap_ssh" {
 # Allow Prometheus to scrape the monitoring VM via its external IPv4 address.
 resource "google_compute_firewall" "monitoring_scrape" {
   allow {
-    ports    = ["9115"]
+    ports    = ["9100", "9115"]
     protocol = "tcp"
   }
   description   = "Allow Prometheus to scrape the monitoring VM (managed by Terraform)"


### PR DESCRIPTION
This allows Prometheus to scrape node_exporter on that port.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/136)
<!-- Reviewable:end -->
