### PR TITLE
Changes several machine types from n2 to n4 family

### DIFF
--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -237,21 +237,27 @@ module "platform-cluster" {
       },
       mlab1-cgk03 = {
         zone = "asia-southeast2-a"
+        machine_type = "n4-highcpu-4"
       },
       mlab2-cgk03 = {
         zone = "asia-southeast2-b"
+        machine_type = "n4-highcpu-4"
       },
       mlab3-cgk03 = {
         zone = "asia-southeast2-c"
+        machine_type = "n4-highcpu-4"
       },
       mlab1-tlv03 = {
         zone = "me-west1-a"
+        machine_type = "n4-highcpu-4"
       },
       mlab2-tlv03 = {
         zone = "me-west1-b"
+        machine_type = "n4-highcpu-4"
       },
       mlab3-tlv03 = {
         zone = "me-west1-c"
+        machine_type = "n4-highcpu-4"
       },
 
       # 2-VM sites.
@@ -281,9 +287,11 @@ module "platform-cluster" {
       },
       mlab1-hel03 = {
         zone = "europe-north1-a"
+        machine_type = "n4-highcpu-4"
       },
       mlab2-hel03 = {
         zone = "europe-north1-b"
+        machine_type = "n4-highcpu-4"
       },
       mlab1-hkg06 = {
         zone        = "asia-east2-a"
@@ -344,12 +352,14 @@ module "platform-cluster" {
         probability = 0.5
       },
       mlab1-yyz09 = {
-        zone        = "northamerica-northeast2-a"
-        probability = 0.5
-      },
-      mlab2-yyz09 = {
         zone        = "northamerica-northeast2-b"
         probability = 0.5
+        machine_type = "n4-highcpu-4"
+      },
+      mlab2-yyz09 = {
+        zone        = "northamerica-northeast2-c"
+        probability = 0.5
+        machine_type = "n4-highcpu-4"
       },
       mlab1-zrh03 = {
         zone = "europe-west6-a"
@@ -370,6 +380,7 @@ module "platform-cluster" {
       mlab1-bru08 = {
         zone        = "europe-west1-b"
         probability = 0.5
+        machine_type = "n4-highcpu-4"
       },
       mlab1-chs03 = {
         zone = "us-east1-b"
@@ -418,6 +429,7 @@ module "platform-cluster" {
       },
       mlab1-oma03 = {
         zone = "us-central1-a"
+        machine_type = "n4-highcpu-4"
       },
       mlab1-scl07 = {
         zone        = "southamerica-west1-a"


### PR DESCRIPTION
When trying to deploy the previous configurations to production we got errors for multiple sites that n2-highcpu-4 machines were not currently available in those zones due to a lack of resources. And in once case (me-west1) we exceeded our N2_CPUs quote. This commit changes all those regions to use n4-highcpu-4 machine types in the hopes that those will be available. I checked quotas for N4 cpus and it _seems_ like we have plenty of quote in every region. Additionally, the N2 machine family is getting rather old and N4 is a newer option.

I also modified the zones for region northamerica-northeast2, because gcloud reported that N4 cpus are not available in availability zone A, but are in B and C.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/139)
<!-- Reviewable:end -->
