### PR TITLE
Changes n4-highcpu-4 machine types to e2-highcpu-4

### DIFF
--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -237,27 +237,27 @@ module "platform-cluster" {
       },
       mlab1-cgk03 = {
         zone = "asia-southeast2-a"
-        machine_type = "n4-highcpu-4"
+        machine_type = "e2-highcpu-4"
       },
       mlab2-cgk03 = {
         zone = "asia-southeast2-b"
-        machine_type = "n4-highcpu-4"
+        machine_type = "e2-highcpu-4"
       },
       mlab3-cgk03 = {
         zone = "asia-southeast2-c"
-        machine_type = "n4-highcpu-4"
+        machine_type = "e2-highcpu-4"
       },
       mlab1-tlv03 = {
         zone = "me-west1-a"
-        machine_type = "n4-highcpu-4"
+        machine_type = "e2-highcpu-4"
       },
       mlab2-tlv03 = {
         zone = "me-west1-b"
-        machine_type = "n4-highcpu-4"
+        machine_type = "e2-highcpu-4"
       },
       mlab3-tlv03 = {
         zone = "me-west1-c"
-        machine_type = "n4-highcpu-4"
+        machine_type = "e2-highcpu-4"
       },
 
       # 2-VM sites.
@@ -287,11 +287,11 @@ module "platform-cluster" {
       },
       mlab1-hel03 = {
         zone = "europe-north1-a"
-        machine_type = "n4-highcpu-4"
+        machine_type = "e2-highcpu-4"
       },
       mlab2-hel03 = {
         zone = "europe-north1-b"
-        machine_type = "n4-highcpu-4"
+        machine_type = "e2-highcpu-4"
       },
       mlab1-hkg06 = {
         zone        = "asia-east2-a"
@@ -354,12 +354,12 @@ module "platform-cluster" {
       mlab1-yyz09 = {
         zone        = "northamerica-northeast2-b"
         probability = 0.5
-        machine_type = "n4-highcpu-4"
+        machine_type = "e2-highcpu-4"
       },
       mlab2-yyz09 = {
         zone        = "northamerica-northeast2-c"
         probability = 0.5
-        machine_type = "n4-highcpu-4"
+        machine_type = "e2-highcpu-4"
       },
       mlab1-zrh03 = {
         zone = "europe-west6-a"
@@ -380,7 +380,7 @@ module "platform-cluster" {
       mlab1-bru08 = {
         zone        = "europe-west1-b"
         probability = 0.5
-        machine_type = "n4-highcpu-4"
+        machine_type = "e2-highcpu-4"
       },
       mlab1-chs03 = {
         zone = "us-east1-b"
@@ -429,7 +429,7 @@ module "platform-cluster" {
       },
       mlab1-oma03 = {
         zone = "us-central1-a"
-        machine_type = "n4-highcpu-4"
+        machine_type = "e2-highcpu-4"
       },
       mlab1-scl07 = {
         zone        = "southamerica-west1-a"


### PR DESCRIPTION
The recent switch from n2-highcpu-4 to n4-highcpu-4 (to work around N2 capacity/quota shortages in several regions) broke Terraform builds: n4 machines only support Hyperdisk and reject the pd-ssd boot disk that all platform VMs share via instances.attributes.disk_type. Rather than make disk_type per-instance overridable to pair n4 with hyperdisk-balanced, switch these to e2-highcpu-4, which supports pd-ssd, is already used at several other sites without impacting measurement quality, and has the widest regional availability to address the original capacity problem.

 Co-Authored-By: Claude Opus 4.8

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/140)
<!-- Reviewable:end -->
