### PR TITLE
Changes us-east5 from n2 to e2, and moves it to zone C

### DIFF
--- a/mlab-oti/platform-cluster.tf
+++ b/mlab-oti/platform-cluster.tf
@@ -386,7 +386,8 @@ module "platform-cluster" {
         zone = "us-east1-b"
       },
       mlab1-cmh03 = {
-        zone = "us-east5-a"
+        zone = "us-east5-c"
+        machine_type = "e2-highcpu-4"
       },
       mlab1-fra09 = {
         zone        = "europe-west3-a"


### PR DESCRIPTION
Deploying an n2-highcpu-4 VM to us-east5-a failed due to a lack of availability of that machine type in that zone. I changed it to an e2-highcpu-4, but even that failed to deploy in zones A and B, but finally worked in zone C.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/terraform-support/141)
<!-- Reviewable:end -->
